### PR TITLE
Add logic to update person balance

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/UpdateAccountDetailsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/UpdateAccountDetailsSteps.cs
@@ -71,7 +71,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
         public async Task ThenThePersonIndexIsUpdated(
             string newPaymentReference,
             decimal newTotalBalance,
-            TenureInformation tenure, 
+            TenureInformation tenure,
             IElasticClient esClient)
         {
             foreach (var hm in tenure.HouseholdMembers)

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/UpdateAccountDetailsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/UpdateAccountDetailsSteps.cs
@@ -69,7 +69,10 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
         }
 
         public async Task ThenThePersonIndexIsUpdated(
-            string newPaymentReference, TenureInformation tenure, IElasticClient esClient)
+            string newPaymentReference,
+            decimal newTotalBalance,
+            TenureInformation tenure, 
+            IElasticClient esClient)
         {
             foreach (var hm in tenure.HouseholdMembers)
             {
@@ -79,6 +82,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
 
                 var personTenure = personInIndex.Tenures.First(x => x.Id == tenure.Id);
                 personTenure.PaymentReference.Should().Be(newPaymentReference);
+                personTenure.TotalBalance.Should().Be(newTotalBalance);
             }
         }
     }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/UpdateAccountDetailsTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/UpdateAccountDetailsTests.cs
@@ -87,6 +87,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenTheTenureIndexIsUpdated(_accountApiFixture.ResponseObject.PaymentReference,
                                                               _tenureApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .Then(t => _steps.ThenThePersonIndexIsUpdated(_accountApiFixture.ResponseObject.PaymentReference,
+                                                              _accountApiFixture.ResponseObject.AccountBalance,
                                                               _tenureApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();
         }

--- a/HousingSearchListener/V1/Boundary/EventTypes.cs
+++ b/HousingSearchListener/V1/Boundary/EventTypes.cs
@@ -11,6 +11,7 @@
         public const string PersonRemovedFromTenureEvent = "PersonRemovedFromTenureEvent";
 
         public const string AccountCreatedEvent = "AccountCreatedEvent";
+        public const string AccountUpdatedEvent = "AccountUpdatedEvent";
         public const string TransactionCreatedEvent = "TransactionCreatedEvent";
     }
 }

--- a/HousingSearchListener/V1/Factories/UseCaseFactory.cs
+++ b/HousingSearchListener/V1/Factories/UseCaseFactory.cs
@@ -43,6 +43,7 @@ namespace HousingSearchListener.V1.Factories
                         break;
                     }
                 case EventTypes.AccountCreatedEvent:
+                case EventTypes.AccountUpdatedEvent:
                     {
                         processor = serviceProvider.GetService<IUpdateAccountDetailsUseCase>();
                         break;

--- a/HousingSearchListener/V1/UseCase/UpdateAccountDetailsUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/UpdateAccountDetailsUseCase.cs
@@ -77,7 +77,10 @@ namespace HousingSearchListener.V1.UseCase
         {
             var esPerson = await _esGateway.GetPersonById(personId).ConfigureAwait(false);
             var personTenure = esPerson.Tenures.First(x => x.Id == tenureId);
+
             personTenure.PaymentReference = account.PaymentReference;
+            personTenure.TotalBalance = account.AccountBalance;
+
             await _esGateway.IndexPerson(esPerson);
         }
     }


### PR DESCRIPTION
## Link to ClickUP ticket

https://app.clickup.com/t/1kck3df

## Describe this PR

### *What is the problem we're trying to solve*

Update housing search listener to listen the AccountCreatedEvent and AccountUpdatedEvent to update totalBalance for Person tenures

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly
