### PR TITLE
Removed Hackney.Asset.Shared package from dependencies as it's not in use

### DIFF
--- a/HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
+++ b/HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
@@ -26,7 +26,7 @@
     </PackageReference>
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.49.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.23.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.29.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0" />

--- a/HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
+++ b/HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
@@ -26,7 +26,6 @@
     </PackageReference>
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.49.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.29.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0" />

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
@@ -1,6 +1,5 @@
 ﻿using AutoFixture;
 using Hackney.Core.Testing.Shared.E2E;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using System;
 

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddAssetToIndexSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddAssetToIndexSteps.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using HousingSearchListener.V1.Factories;
 using HousingSearchListener.V1.Infrastructure.Exceptions;

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddProcessToIndexSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddProcessToIndexSteps.cs
@@ -1,8 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Domain.Person;
-using Hackney.Shared.HousingSearch.Domain.Process;
 using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
 using Hackney.Shared.Processes.Domain;
 using Hackney.Shared.Processes.Factories;

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -10,10 +10,6 @@ using HousingSearchListener.V1.Domain.Transaction;
 using Xunit;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
 using Tenure = HousingSearchListener.V1.Domain.Person.Tenure;
-using Hackney.Shared.Asset.Domain;
-using Hackney.Shared.HousingSearch.Domain.Process;
-using Hackney.Shared.Processes.Domain;
-using Process = Hackney.Shared.Processes.Domain.Process;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 

--- a/HousingSearchListener.Tests/V1/Gateway/AssetApiGatewayTests.cs
+++ b/HousingSearchListener.Tests/V1/Gateway/AssetApiGatewayTests.cs
@@ -1,8 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using Hackney.Core.Http;
-using Hackney.Shared.Asset.Boundary.Response;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using HousingSearchListener.V1.Gateway;
 using Moq;

--- a/HousingSearchListener.Tests/V1/UseCase/IndexCreateAssetUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/IndexCreateAssetUseCaseTests.cs
@@ -1,7 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using Hackney.Core.Sns;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using HousingSearchListener.V1.Factories;

--- a/HousingSearchListener.Tests/V1/UseCase/IndexProcessUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/IndexProcessUseCaseTests.cs
@@ -1,13 +1,10 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using Hackney.Core.Sns;
-using Hackney.Shared.Asset.Domain;
-using Hackney.Shared.HousingSearch.Domain.Process;
 using Hackney.Shared.HousingSearch.Factories;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
 using Hackney.Shared.Processes.Domain;
-using Hackney.Shared.Processes.Factories;
 using HousingSearchListener.V1.Domain.Person;
 using HousingSearchListener.V1.Domain.Tenure;
 using HousingSearchListener.V1.Factories;

--- a/HousingSearchListener.Tests/V1/UseCase/UpdateAssetUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/UpdateAssetUseCaseTests.cs
@@ -1,7 +1,6 @@
 ﻿using AutoFixture;
 using FluentAssertions;
 using Hackney.Core.Sns;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using HousingSearchListener.V1.Factories;

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.68.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.29.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.68.0" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.23.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.29.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -1,9 +1,6 @@
-using Hackney.Shared.Asset.Domain;
-using Hackney.Shared.HousingSearch.Domain.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Persons;
-using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
 using Hackney.Shared.HousingSearch.Gateways.Models.Transactions;
 using HousingSearchListener.V1.Domain.Person;

--- a/HousingSearchListener/V1/Factories/IESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/IESEntityFactory.cs
@@ -6,9 +6,6 @@ using System.Collections.Generic;
 using Hackney.Shared.HousingSearch.Gateways.Models.Transactions;
 using HousingSearchListener.V1.Domain.Transaction;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
-using Hackney.Shared.Asset.Domain;
-using Hackney.Shared.HousingSearch.Gateways.Models.Processes;
-using Hackney.Shared.HousingSearch.Domain.Process;
 
 namespace HousingSearchListener.V1.Factories
 {

--- a/HousingSearchListener/V1/Gateway/AssetApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/AssetApiGateway.cs
@@ -1,6 +1,5 @@
 ﻿using Hackney.Core.Http;
 using Hackney.Core.Logging;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using HousingSearchListener.V1.Gateway.Interfaces;
 using System;

--- a/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
@@ -1,6 +1,5 @@
 ﻿using Hackney.Core.Http;
 using Hackney.Core.Logging;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using HousingSearchListener.V1.Gateway.Interfaces;
 using System;

--- a/HousingSearchListener/V1/Gateway/Interfaces/IAssetApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/Interfaces/IAssetApiGateway.cs
@@ -1,5 +1,4 @@
-﻿using Hackney.Shared.Asset.Domain;
-using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+﻿using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using System;
 using System.Threading.Tasks;
 

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -1,6 +1,5 @@
 ﻿using Hackney.Core.Logging;
 using Hackney.Core.Sns;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;

--- a/HousingSearchListener/V1/UseCase/IndexCreateAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/IndexCreateAssetUseCase.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Hackney.Core.Logging;
 using Hackney.Core.Sns;
 using HousingSearchListener.V1.Gateway.Interfaces;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 
 namespace HousingSearchListener.V1.UseCase

--- a/HousingSearchListener/V1/UseCase/IndexProcessUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/IndexProcessUseCase.cs
@@ -8,15 +8,12 @@ using Hackney.Core.Sns;
 using HousingSearchListener.V1.Gateway.Interfaces;
 using System.Collections.Generic;
 using Hackney.Shared.Tenure.Domain;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Domain.Person;
 using HousingSearchApi.V1.Factories;
 using HousingSearchListener.V1.UseCase.Exceptions;
 using Hackney.Shared.Processes.Domain;
-using HousingSearchProcess = Hackney.Shared.HousingSearch.Domain.Process.Process;
 using Hackney.Shared.HousingSearch.Factories;
 using Process = Hackney.Shared.Processes.Domain.Process;
-using Hackney.Shared.Processes.Factories;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 
 namespace HousingSearchListener.V1.UseCase

--- a/HousingSearchListener/V1/UseCase/UpdateAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/UpdateAssetUseCase.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Hackney.Core.Logging;
 using Hackney.Core.Sns;
 using HousingSearchListener.V1.Gateway.Interfaces;
-using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 
 namespace HousingSearchListener.V1.UseCase


### PR DESCRIPTION
## Link to JIRA ticket

MR-698 - https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?modal=detail&selectedIssue=MR-698

## Describe this PR

### *What is the problem we're trying to solve*

Given the recent update to Hackney.Asset.Shared to v 0.30, we have been reviewing all solutions that use this library and make any adjustments if necessary.

### *What changes have we introduced*

- Removed Hackney.Asset.Shared package from dependencies as it's not in use
- Removed unnecessary usings from files where Hackney.Asset.Shared was listed as an "import", despite not being in use.

### *Changes introduced by in Hackney.Asset.Shared*
Properties within the AssetDb class (within Hackney.Asset.Shared) of type 'int' and 'boolean' have been set from non-nullable to nullable with the latest update of the library, to version 0.30.

