### PR TITLE
TS-1389 Add temporary accommodation booking status to tenure

### DIFF
--- a/HousingSearchListener.Tests/ElasticSearchFixture.cs
+++ b/HousingSearchListener.Tests/ElasticSearchFixture.cs
@@ -165,7 +165,7 @@ namespace HousingSearchListener.Tests
             esTenure.EndOfTenureDate = null;
             esTenure.PaymentReference = null;
             esTenure.TenuredAsset.FullAddress = "Somewhere";
-            esTenure.TemporaryAccommodationInfo.BookingStatus = "Some booking status";
+            esTenure.TempAccommodationInfo.BookingStatus = "Some booking status";
             var request = new IndexRequest<QueryableTenure>(esTenure, IndexNameTenures);
             await ElasticSearchClient.IndexAsync(request).ConfigureAwait(false);
         }

--- a/HousingSearchListener.Tests/ElasticSearchFixture.cs
+++ b/HousingSearchListener.Tests/ElasticSearchFixture.cs
@@ -165,6 +165,7 @@ namespace HousingSearchListener.Tests
             esTenure.EndOfTenureDate = null;
             esTenure.PaymentReference = null;
             esTenure.TenuredAsset.FullAddress = "Somewhere";
+            esTenure.TemporaryAccommodationInfo.BookingStatus = "Some booking status";
             var request = new IndexRequest<QueryableTenure>(esTenure, IndexNameTenures);
             await ElasticSearchClient.IndexAsync(request).ConfigureAwait(false);
         }

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -63,7 +63,7 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.StartOfTenureDate.Should().Be(domainTenure.StartOfTenureDate);
             result.TenuredAsset.Should().BeEquivalentTo(domainTenure.TenuredAsset);
             result.TenureType.Should().BeEquivalentTo(domainTenure.TenureType);
-            result.TemporaryAccommodationInfo.Should().BeEquivalentTo(domainTenure.TemporaryAccommodationInfo);
+            result.TempAccommodationInfo.Should().BeEquivalentTo(domainTenure.TempAccommodationInfo);
         }
 
         [Fact]

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -63,6 +63,7 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.StartOfTenureDate.Should().Be(domainTenure.StartOfTenureDate);
             result.TenuredAsset.Should().BeEquivalentTo(domainTenure.TenuredAsset);
             result.TenureType.Should().BeEquivalentTo(domainTenure.TenureType);
+            result.TemporaryAccommodationInfo.Should().BeEquivalentTo(domainTenure.TemporaryAccommodationInfo);
         }
 
         [Fact]

--- a/HousingSearchListener.Tests/data/indexes/tenureIndex.json
+++ b/HousingSearchListener.Tests/data/indexes/tenureIndex.json
@@ -143,6 +143,19 @@
             }
           }
         }
+      },
+      "temporaryAccommodationInfo": {
+        "properties": {
+          "bookingStatus": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0-feat-ts-1389-add0001" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0-feat-ts-1389-add0009" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.68.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0-feat-ts-1389-add0001" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0-feat-ts-1389-add0009" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
@@ -1,6 +1,6 @@
 ﻿namespace HousingSearchListener.V1.Domain.Tenure
 {
-    public class TemporaryAccommodationInfo
+    public class TempAccommodationInfo
     {
         public string BookingStatus { get; set; }
     }

--- a/HousingSearchListener/V1/Domain/Tenure/TemporaryAccommodationInfo.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TemporaryAccommodationInfo.cs
@@ -1,0 +1,7 @@
+﻿namespace HousingSearchListener.V1.Domain.Tenure
+{
+    public class TemporaryAccommodationInfo
+    {
+        public string BookingStatus { get; set; }
+    }
+}

--- a/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
@@ -12,6 +12,6 @@ namespace HousingSearchListener.V1.Domain.Tenure
         public bool IsActive { get; set; }
         public List<HouseholdMembers> HouseholdMembers { get; set; }
         public string PaymentReference { get; set; }
-        public TemporaryAccommodationInfo TemporaryAccommodationInfo { get; set; }
+        public TempAccommodationInfo TempAccommodationInfo { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
@@ -12,5 +12,6 @@ namespace HousingSearchListener.V1.Domain.Tenure
         public bool IsActive { get; set; }
         public List<HouseholdMembers> HouseholdMembers { get; set; }
         public string PaymentReference { get; set; }
+        public TemporaryAccommodationInfo TemporaryAccommodationInfo { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
 using QueryableTenuredAsset = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTenuredAsset;
-using QueryableTemporaryAccommodationInfo = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTemporaryAccommodationInfo;
+using QueryableTempAccommodationInfo = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTempAccommodationInfo;
 
 namespace HousingSearchListener.V1.Factories
 {
@@ -67,7 +67,7 @@ namespace HousingSearchListener.V1.Factories
                     Type = tenure.TenuredAsset?.Type,
                     Uprn = tenure.TenuredAsset?.Uprn
                 },
-                TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTemporaryAccommodationInfo()
+                TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTempAccommodationInfo()
                 {
                     BookingStatus = tenure.TempAccommodationInfo.BookingStatus
                 }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -67,9 +67,9 @@ namespace HousingSearchListener.V1.Factories
                     Type = tenure.TenuredAsset?.Type,
                     Uprn = tenure.TenuredAsset?.Uprn
                 },
-                TemporaryAccommodationInfo = new QueryableTemporaryAccommodationInfo()
+                TemporaryAccommodationInfo = tenure.TemporaryAccommodationInfo == null ? null : new QueryableTemporaryAccommodationInfo()
                 {
-                    BookingStatus = tenure.TemporaryAccommodationInfo?.BookingStatus
+                    BookingStatus = tenure.TemporaryAccommodationInfo.BookingStatus
                 }
             };
         }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -67,9 +67,9 @@ namespace HousingSearchListener.V1.Factories
                     Type = tenure.TenuredAsset?.Type,
                     Uprn = tenure.TenuredAsset?.Uprn
                 },
-                TemporaryAccommodationInfo = tenure.TemporaryAccommodationInfo == null ? null : new QueryableTemporaryAccommodationInfo()
+                TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTemporaryAccommodationInfo()
                 {
-                    BookingStatus = tenure.TemporaryAccommodationInfo.BookingStatus
+                    BookingStatus = tenure.TempAccommodationInfo.BookingStatus
                 }
             };
         }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
 using QueryableTenuredAsset = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTenuredAsset;
+using QueryableTemporaryAccommodationInfo = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTemporaryAccommodationInfo;
 
 namespace HousingSearchListener.V1.Factories
 {
@@ -65,6 +66,10 @@ namespace HousingSearchListener.V1.Factories
                     Id = tenure.TenuredAsset?.Id,
                     Type = tenure.TenuredAsset?.Type,
                     Uprn = tenure.TenuredAsset?.Uprn
+                },
+                TemporaryAccommodationInfo = new QueryableTemporaryAccommodationInfo()
+                {
+                    BookingStatus = tenure.TemporaryAccommodationInfo?.BookingStatus
                 }
             };
         }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1389](https://hackney.atlassian.net/browse/TS-1389)

## Describe this PR

### *What is the problem we're trying to solve*

We are working on new worktray feature for temporary accommodation officers in the Book Temporary Accommodation app. The worktray is powered by the tenure index in the housing search that this listener maintains. Currently we are not storing the booking status to the tenure index, so it's not available to clients. 

### *What changes have we introduced*

`QueryableTenure` model in the `Hackney.Shared.HousingSearch` package has been updated ([PR](https://github.com/LBHackney-IT/housing-search-shared/pull/73)) to include `QueryableTempAccommodationInfo` which includes the booking status details and this change implements the updated property by including it in to the tenure index to make it available for clients. It's worth noting that the `TempAccommodationInfo` object will be added to the Tenure object in the search index only if it contains data. 

`HousingSearchListener.Tests/data/indexes/tenureIndex.json` file is used to create the tenure index during tests setup, so it has been updated as well. However this setup seems a bit redundant since all tests handle the indexes independently and don't rely on this intial setup. Perhaps its purpose is to support local dev/debugging in some other way.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly


[TS-1389]: https://hackney.atlassian.net/browse/TS-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ