### PR TITLE
TS-1403 add assigned officer support for TA

### DIFF
--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -12,7 +12,6 @@ using Person = HousingSearchListener.V1.Domain.Person.Person;
 using Tenure = HousingSearchListener.V1.Domain.Person.Tenure;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
-using TestStack.BDDfy;
 
 namespace HousingSearchListener.Tests.V1.Factories
 {

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -66,7 +66,7 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.TenureType.Should().BeEquivalentTo(domainTenure.TenureType);
             result.TempAccommodationInfo.Should().BeEquivalentTo(domainTenure.TempAccommodationInfo);
         }
-        
+
         [Fact]
         public void CreateQueryableTenureSetsTempAccommodationInfoToNullWhenPropertyIsNullInDomain()
         {

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -66,17 +66,7 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.TenureType.Should().BeEquivalentTo(domainTenure.TenureType);
             result.TempAccommodationInfo.Should().BeEquivalentTo(domainTenure.TempAccommodationInfo);
         }
-
-        [Fact]
-        public void CreateQueryableTenureAddsTempAccommodationProperties()
-        {
-            var domainTenure = _fixture.Create<TenureInformation>();
-
-            var result = _sut.CreateQueryableTenure(domainTenure);
-            result.TempAccommodationInfo.BookingStatus.Should().Be(domainTenure.TempAccommodationInfo.BookingStatus);
-            result.TempAccommodationInfo.AssignedOfficer.Should().Be(domainTenure.TempAccommodationInfo.AssignedOfficer);
-        }
-
+        
         [Fact]
         public void CreateQueryableTenureSetsTempAccommodationInfoToNullWhenPropertyIsNullInDomain()
         {

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -12,6 +12,7 @@ using Person = HousingSearchListener.V1.Domain.Person.Person;
 using Tenure = HousingSearchListener.V1.Domain.Person.Tenure;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
+using TestStack.BDDfy;
 
 namespace HousingSearchListener.Tests.V1.Factories
 {
@@ -64,6 +65,26 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.TenuredAsset.Should().BeEquivalentTo(domainTenure.TenuredAsset);
             result.TenureType.Should().BeEquivalentTo(domainTenure.TenureType);
             result.TempAccommodationInfo.Should().BeEquivalentTo(domainTenure.TempAccommodationInfo);
+        }
+
+        [Fact]
+        public void CreateQueryableTenureAddsTempAccommodationProperties()
+        {
+            var domainTenure = _fixture.Create<TenureInformation>();
+
+            var result = _sut.CreateQueryableTenure(domainTenure);
+            result.TempAccommodationInfo.BookingStatus.Should().Be(domainTenure.TempAccommodationInfo.BookingStatus);
+            result.TempAccommodationInfo.AssignedOfficer.Should().Be(domainTenure.TempAccommodationInfo.AssignedOfficer);
+        }
+
+        [Fact]
+        public void CreateQueryableTenureSetsTempAccommodationInfoToNullWhenPropertyIsNullInDomain()
+        {
+            var domainTenure = _fixture.Create<TenureInformation>();
+            domainTenure.TempAccommodationInfo = null;
+            
+            var result = _sut.CreateQueryableTenure(domainTenure);
+            result.TempAccommodationInfo.Should().BeNull();
         }
 
         [Fact]

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -82,7 +82,7 @@ namespace HousingSearchListener.Tests.V1.Factories
         {
             var domainTenure = _fixture.Create<TenureInformation>();
             domainTenure.TempAccommodationInfo = null;
-            
+
             var result = _sut.CreateQueryableTenure(domainTenure);
             result.TempAccommodationInfo.Should().BeNull();
         }

--- a/HousingSearchListener.Tests/data/indexes/tenureIndex.json
+++ b/HousingSearchListener.Tests/data/indexes/tenureIndex.json
@@ -154,6 +154,15 @@
                 "ignore_above": 256
               }
             }
+          },
+          "assignedOfficer": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           }
         }
       }

--- a/HousingSearchListener.Tests/data/indexes/tenureIndex.json
+++ b/HousingSearchListener.Tests/data/indexes/tenureIndex.json
@@ -156,11 +156,33 @@
             }
           },
           "assignedOfficer": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
+            "properties": {
+              "firstName": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "lastName": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "email": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
               }
             }
           }

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0-feat-ts-1401-0002" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0-feat-ts-1401-0004" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.70.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0-feat-ts-1401-0001" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0-feat-ts-1401-0004" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0-feat-ts-1401-0001" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0-feat-ts-1401-0002" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
@@ -3,5 +3,6 @@
     public class TempAccommodationInfo
     {
         public string BookingStatus { get; set; }
+        public string AssignedOfficer { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
@@ -3,6 +3,6 @@
     public class TempAccommodationInfo
     {
         public string BookingStatus { get; set; }
-        public string AssignedOfficer { get; set; }
+        public TempAccommodationOfficer AssignedOfficer { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Domain/Tenure/TempAccommodationOfficer.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TempAccommodationOfficer.cs
@@ -1,0 +1,9 @@
+﻿namespace HousingSearchListener.V1.Domain.Tenure
+{
+    public  class TempAccommodationOfficer
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/HousingSearchListener/V1/Domain/Tenure/TempAccommodationOfficer.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TempAccommodationOfficer.cs
@@ -1,6 +1,6 @@
 ﻿namespace HousingSearchListener.V1.Domain.Tenure
 {
-    public  class TempAccommodationOfficer
+    public class TempAccommodationOfficer
     {
         public string FirstName { get; set; }
         public string LastName { get; set; }

--- a/HousingSearchListener/V1/Domain/Tenure/TenuredAsset.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TenuredAsset.cs
@@ -6,5 +6,6 @@
         public string Type { get; set; }
         public string FullAddress { get; set; }
         public string Uprn { get; set; }
+        public bool? IsTemporaryAccommodation { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Domain/Tenure/TenuredAsset.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TenuredAsset.cs
@@ -6,6 +6,5 @@
         public string Type { get; set; }
         public string FullAddress { get; set; }
         public string Uprn { get; set; }
-        public bool? IsTemporaryAccommodation { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -12,7 +12,7 @@ using System.Linq;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
 using QueryableTenuredAsset = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTenuredAsset;
 using QueryableTempAccommodationInfo = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTempAccommodationInfo;
-using TemporaryAccommodationOfficer = Hackney.Shared.HousingSearch.Domain.Tenure.TemporaryAccommodationOfficer;
+using TemporaryAccommodationOfficer = Hackney.Shared.HousingSearch.Domain.Tenure.TempAccommodationOfficer;
 
 namespace HousingSearchListener.V1.Factories
 {
@@ -66,7 +66,8 @@ namespace HousingSearchListener.V1.Factories
                     FullAddress = tenure.TenuredAsset?.FullAddress,
                     Id = tenure.TenuredAsset?.Id,
                     Type = tenure.TenuredAsset?.Type,
-                    Uprn = tenure.TenuredAsset?.Uprn
+                    Uprn = tenure.TenuredAsset?.Uprn,
+                    IsTemporaryAccommodation = tenure.TenuredAsset?.IsTemporaryAccommodation
                 },
                 TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTempAccommodationInfo()
                 {

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -11,8 +11,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
 using QueryableTenuredAsset = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTenuredAsset;
-using QueryableTempAccommodationInfo = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTempAccommodationInfo;
-using TemporaryAccommodationOfficer = Hackney.Shared.HousingSearch.Domain.Tenure.TempAccommodationOfficer;
 
 namespace HousingSearchListener.V1.Factories
 {
@@ -71,7 +69,7 @@ namespace HousingSearchListener.V1.Factories
                 TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTempAccommodationInfo()
                 {
                     BookingStatus = tenure.TempAccommodationInfo.BookingStatus,
-                    AssignedOfficer = new TemporaryAccommodationOfficer()
+                    AssignedOfficer = new QueryableTempAccommodationOfficer
                     {
                         FirstName = tenure.TempAccommodationInfo.AssignedOfficer?.FirstName,
                         LastName = tenure.TempAccommodationInfo.AssignedOfficer?.LastName,

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -66,8 +66,7 @@ namespace HousingSearchListener.V1.Factories
                     FullAddress = tenure.TenuredAsset?.FullAddress,
                     Id = tenure.TenuredAsset?.Id,
                     Type = tenure.TenuredAsset?.Type,
-                    Uprn = tenure.TenuredAsset?.Uprn,
-                    IsTemporaryAccommodation = tenure.TenuredAsset?.IsTemporaryAccommodation
+                    Uprn = tenure.TenuredAsset?.Uprn
                 },
                 TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTempAccommodationInfo()
                 {

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
 using QueryableTenuredAsset = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTenuredAsset;
 using QueryableTempAccommodationInfo = Hackney.Shared.HousingSearch.Gateways.Models.Tenures.QueryableTempAccommodationInfo;
+using TemporaryAccommodationOfficer = Hackney.Shared.HousingSearch.Domain.Tenure.TemporaryAccommodationOfficer;
 
 namespace HousingSearchListener.V1.Factories
 {
@@ -70,7 +71,12 @@ namespace HousingSearchListener.V1.Factories
                 TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTempAccommodationInfo()
                 {
                     BookingStatus = tenure.TempAccommodationInfo.BookingStatus,
-                    AssignedOfficer = tenure.TempAccommodationInfo.AssignedOfficer
+                    AssignedOfficer = new TemporaryAccommodationOfficer()
+                    {
+                        FirstName = tenure.TempAccommodationInfo.AssignedOfficer?.FirstName,
+                        LastName = tenure.TempAccommodationInfo.AssignedOfficer?.LastName,
+                        Email = tenure.TempAccommodationInfo.AssignedOfficer?.Email
+                    }
                 }
             };
         }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -69,7 +69,8 @@ namespace HousingSearchListener.V1.Factories
                 },
                 TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTempAccommodationInfo()
                 {
-                    BookingStatus = tenure.TempAccommodationInfo.BookingStatus
+                    BookingStatus = tenure.TempAccommodationInfo.BookingStatus,
+                    AssignedOfficer = tenure.TempAccommodationInfo.AssignedOfficer
                 }
             };
         }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1403](https://hackney.atlassian.net/browse/TS-1403)

## Describe this PR

### *What is the problem we're trying to solve*

We are working on new worktray feature for temporary accommodation officers in the Book Temporary Accommodation app. The worktray is powered by the tenure index in the housing search that this listener maintains. Currently we are not storing the assigned officer details for the booking in the tenure index, so it's not available to clients. 

### *What changes have we introduced*

Update the `TempAccommodationInfo` object with new `AssignedOfficer` property and update the `CreateQueryableTenure` method to store the officer details to the tenure index object.

Add additional test to verify the `QueryableTenure` object shape when TA details are not provided.

Update the `Hackney.Shared.HousingSearch` package to 0.71.0 which includes the assigned officer details. ([related PR for the shared package](https://github.com/LBHackney-IT/housing-search-shared/pull/74))

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

[TS-1403]: https://hackney.atlassian.net/browse/TS-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ