### PR TITLE
TS-1325 Add IsTemporaryAccommodation flag to tenuredAsset

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/TenureApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/TenureApiFixture.cs
@@ -48,6 +48,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
             var newData = oldData.DeepClone();
 
             var newHm = CreateHouseholdMembers(1).First();
+            newHm.IsResponsible = true; //ensure newly added person is always the responsible one which makes them a tenant. This is the expected state in the index
             newData.Add(newHm);
             AddedPersonId = Guid.Parse(newHm.Id);
 

--- a/HousingSearchListener.Tests/V1/UseCase/AddPersonToTenureUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/AddPersonToTenureUseCaseTests.cs
@@ -241,6 +241,7 @@ namespace HousingSearchListener.Tests.V1.UseCase
                         .With(x => x.Id, Guid.NewGuid().ToString())
                         .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-40).ToString(DateFormat))
                         .With(x => x.PersonTenureType, "Tenant")
+                        .With(x => x.IsResponsible, true) //ensure TenureTypes.GetPersonTenureType always returns Tenant for this person which is the expected state in the index in VerifyPersonIndexed
                         .Create()
                 : null;
 

--- a/HousingSearchListener/V1/Domain/Tenure/TenuredAsset.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TenuredAsset.cs
@@ -6,5 +6,6 @@
         public string Type { get; set; }
         public string FullAddress { get; set; }
         public string Uprn { get; set; }
+        public bool? IsTemporaryAccommodation { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -64,7 +64,8 @@ namespace HousingSearchListener.V1.Factories
                     FullAddress = tenure.TenuredAsset?.FullAddress,
                     Id = tenure.TenuredAsset?.Id,
                     Type = tenure.TenuredAsset?.Type,
-                    Uprn = tenure.TenuredAsset?.Uprn
+                    Uprn = tenure.TenuredAsset?.Uprn,
+                    IsTemporaryAccommodation = tenure.TenuredAsset?.IsTemporaryAccommodation
                 },
                 TempAccommodationInfo = tenure.TempAccommodationInfo == null ? null : new QueryableTempAccommodationInfo()
                 {


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1325](https://hackney.atlassian.net/browse/TS-1325)

## Describe this PR

### *What is the problem we're trying to solve*

Current `TenuredAsset` object does not have `IsTemporaryAccommodation` property in it, so it's not possible to filter tenures based on their temporary accommodation (TA) status. This makes the TA worktray inefficient because it's using the tenure index as a data source and is only interested in TA tenures.

### *What changes have we introduced*

Add `IsTemporaryAccommodation` flag to `TenuredAsset`.

Related `AddPersonToTenureUseCaseTests` test fixtures have been updated to ensure the new person added to the tenure is always responsible for the tenure. This ensure that when `TenureTypes.GetPersonTenureType` method is called to determine the person's tenure type it always returns "Tenant" which is the expected state in the index.

Previously when the `isResponsible` value was not set in the test fixtures, the tests were passing when `_fixture` happened to set it to true, but were failing when set to false. Locking the `isResponsible` value down in the fixture ensures the test setup is always the same. `AutoFixture` creates boolean values by using algorithm where the first value is true, then false, then true etc., so unless the boolean values are set to fit the use case for each test the outcome can be unpredictable.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*
N/A
