### PR TITLE
TS-1406 add assigned officer id support for temporary accommodation

### DIFF
--- a/HousingSearchListener.Tests/data/indexes/tenureIndex.json
+++ b/HousingSearchListener.Tests/data/indexes/tenureIndex.json
@@ -157,6 +157,15 @@
           },
           "assignedOfficer": {
             "properties": {
+              "id": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
               "firstName": {
                 "type": "text",
                 "fields": {

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.72.0-feat-ts-1406-add0004" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.72.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.71.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.72.0-feat-ts-1406-add0004" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TempAccommodationInfo.cs
@@ -1,8 +1,0 @@
-﻿namespace HousingSearchListener.V1.Domain.Tenure
-{
-    public class TempAccommodationInfo
-    {
-        public string BookingStatus { get; set; }
-        public TempAccommodationOfficer AssignedOfficer { get; set; }
-    }
-}

--- a/HousingSearchListener/V1/Domain/Tenure/TempAccommodationOfficer.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TempAccommodationOfficer.cs
@@ -1,9 +1,0 @@
-﻿namespace HousingSearchListener.V1.Domain.Tenure
-{
-    public class TempAccommodationOfficer
-    {
-        public string FirstName { get; set; }
-        public string LastName { get; set; }
-        public string Email { get; set; }
-    }
-}

--- a/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
@@ -13,7 +13,7 @@ namespace HousingSearchListener.V1.Domain.Tenure
         public bool IsActive { get; set; }
         public List<HouseholdMembers> HouseholdMembers { get; set; }
         public string PaymentReference { get; set; }
-        
+
         //use TempAccommodationInfo from Hackney.Shared.HousingSearch.Domain.Tenure to avoid duplicating objects
         public TempAccommodationInfo TempAccommodationInfo { get; set; }
     }

--- a/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
+++ b/HousingSearchListener/V1/Domain/Tenure/TenureInformation.cs
@@ -1,3 +1,4 @@
+using Hackney.Shared.HousingSearch.Domain.Tenure;
 using System.Collections.Generic;
 
 namespace HousingSearchListener.V1.Domain.Tenure
@@ -12,6 +13,8 @@ namespace HousingSearchListener.V1.Domain.Tenure
         public bool IsActive { get; set; }
         public List<HouseholdMembers> HouseholdMembers { get; set; }
         public string PaymentReference { get; set; }
+        
+        //use TempAccommodationInfo from Hackney.Shared.HousingSearch.Domain.Tenure to avoid duplicating objects
         public TempAccommodationInfo TempAccommodationInfo { get; set; }
     }
 }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -74,7 +74,8 @@ namespace HousingSearchListener.V1.Factories
                     {
                         FirstName = tenure.TempAccommodationInfo.AssignedOfficer?.FirstName,
                         LastName = tenure.TempAccommodationInfo.AssignedOfficer?.LastName,
-                        Email = tenure.TempAccommodationInfo.AssignedOfficer?.Email
+                        Email = tenure.TempAccommodationInfo.AssignedOfficer?.Email,
+                        Id = tenure.TempAccommodationInfo.AssignedOfficer?.Id
                     }
                 }
             };


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1406](https://hackney.atlassian.net/browse/TS-1406)

## Describe this PR

### *What is the problem we're trying to solve*

Current `TempAccommodationOfficer` model in the shared search package does not have Id in it, so we can't use the Ids on the front end to identify officers.

### *What changes have we introduced*

1. Update the `Hackney.Shared.HousingSearch` package to version 0.72.0 which adds the officer id support.
2. Remove `TempAccommodationInfo` and `TempAccommodationOfficer` domain models and use the ones from the shared package instead. There's no value duplicating objects in this use case, so to simplify things they have been removed


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*
None


[TS-1406]: https://hackney.atlassian.net/browse/TS-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ