### PR TITLE
Update shared package to 0.73.0

### DIFF
--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.72.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.73.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />


### PR DESCRIPTION
### What
This PR updates the housing search shared package to the latest 0.73.0.
### Why
To introduce the new nullable fields from this [PR](https://github.com/LBHackney-IT/housing-search-shared/pull/77)