### PR TITLE
Pin serverless version to v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |


### PR DESCRIPTION
### What
Title says all.
### Why
To resolve a deployment issue relating to using serverless V4 and to continue to deploy without a licence. 
