### PR TITLE
TS-1501: Extend housing search listener to populate additional contract fields in the ES index

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
@@ -13,7 +13,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
             : base(FixtureConstants.ContractsApiRoute, FixtureConstants.ContractsApiToken)
         {
             Environment.SetEnvironmentVariable("ContractApiUrl", FixtureConstants.ContractsApiRoute);
-            Environment.SetEnvironmentVariable("ContracttApiToken", FixtureConstants.ContractsApiToken);
+            Environment.SetEnvironmentVariable("ContractApiToken", FixtureConstants.ContractsApiToken);
         }
 
         protected override void Dispose(bool disposing)
@@ -29,10 +29,12 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
             // Nothing to do here
         }
 
-        public Contract GivenTheContractExists(Guid id)
+        public Contract GivenTheContractExists(Guid contractId, Guid targetId)
         {
             ResponseObject = _fixture.Build<Contract>()
-                                     .With(x => x.Id, id.ToString())
+                                     .With(x => x.Id, contractId.ToString())
+                                     .With(x => x.TargetId, targetId.ToString())
+                                     .With(x => x.TargetType, "asset")
                                      .Create();
 
             return ResponseObject;

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+using HousingSearchListener.V1.Factories;
+using HousingSearchListener.V1.Infrastructure.Exceptions;
+using Nest;
+using System;
+using System.Threading.Tasks;
+using Hackney.Shared.HousingSearch.Domain.Contract;
+using EventTypes = HousingSearchListener.V1.Boundary.EventTypes;
+
+namespace HousingSearchListener.Tests.V1.E2ETests.Steps
+{
+    public class AddOrUpdateContractOnAssetTestsSteps : BaseSteps
+    {
+        private readonly ESEntityFactory _entityFactory = new ESEntityFactory();
+
+        public AddOrUpdateContractOnAssetTestsSteps()
+        {
+            _eventType = EventTypes.ContractCreatedEvent;
+        }
+
+        public async Task WhenTheFunctionIsTriggered(Guid contractId, string eventType)
+        {
+            var eventMsg = CreateEvent(contractId, eventType);
+            await TriggerFunction(CreateMessage(eventMsg));
+        }
+
+        public void ThenAContractNotFoundExceptionIsThrown(Guid id)
+        {
+            _lastException.Should().NotBeNull();
+            _lastException.Should().BeOfType(typeof(EntityNotFoundException<Contract>));
+            (_lastException as EntityNotFoundException<Contract>).Id.Should().Be(id);
+        }
+        
+        public void ThenAnAssetNotFoundExceptionIsThrown(Guid id)
+        {
+            _lastException.Should().NotBeNull();
+            _lastException.Should().BeOfType(typeof(EntityNotFoundException<QueryableAsset>));
+            (_lastException as EntityNotFoundException<QueryableAsset>).Id.Should().Be(id);
+        }
+
+        public async Task ThenTheAssetInTheIndexIsUpdatedWithTheContract(
+            QueryableAsset asset, Contract contract, IElasticClient esClient)
+        {
+            var result = await esClient.GetAsync<QueryableAsset>(asset.Id, g => g.Index("assets"))
+                                       .ConfigureAwait(false);
+
+            var assetInIndex = result.Source;
+            assetInIndex.AssetContract.Should().BeEquivalentTo(contract);
+        }
+    }
+}

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -31,7 +31,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
             _lastException.Should().BeOfType(typeof(EntityNotFoundException<Contract>));
             (_lastException as EntityNotFoundException<Contract>).Id.Should().Be(id);
         }
-        
+
         public void ThenAnAssetNotFoundExceptionIsThrown(Guid id)
         {
             _lastException.Should().NotBeNull();

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
-using HousingSearchListener.V1.Factories;
 using HousingSearchListener.V1.Infrastructure.Exceptions;
 using Nest;
 using System;
@@ -12,8 +11,6 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
 {
     public class AddOrUpdateContractOnAssetTestsSteps : BaseSteps
     {
-        private readonly ESEntityFactory _entityFactory = new ESEntityFactory();
-
         public AddOrUpdateContractOnAssetTestsSteps()
         {
             _eventType = EventTypes.ContractCreatedEvent;

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -1,0 +1,93 @@
+﻿using HousingSearchListener.Tests.V1.E2ETests.Fixtures;
+using HousingSearchListener.Tests.V1.E2ETests.Steps;
+using HousingSearchListener.V1.Boundary;
+using System;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace HousingSearchListener.Tests.V1.E2ETests.Stories
+{
+    [Story(
+        AsA = "SQS Contract Listener",
+        IWant = "a function to process the Contract added or updated messages",
+        SoThat = "The Contract details are updated on the Asset in the index")]
+    [Collection("ElasticSearch collection")]
+    public class AddOrUpdateContractOnAssetTests : IDisposable
+    {
+        private readonly ElasticSearchFixture _esFixture;
+        private readonly AssetApiFixture _AssetApiFixture;
+        private readonly ContractApiFixture _ContractApiFixture;
+
+        private readonly AddOrUpdateContractOnAssetTestsSteps _steps;
+
+        public AddOrUpdateContractOnAssetTests(ElasticSearchFixture esFixture)
+        {
+            _esFixture = esFixture;
+            _AssetApiFixture = new AssetApiFixture();
+            _ContractApiFixture = new ContractApiFixture();
+
+            _steps = new AddOrUpdateContractOnAssetTestsSteps();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool _disposed;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                _AssetApiFixture.Dispose();
+                _ContractApiFixture.Dispose();
+
+                _disposed = true;
+            }
+        }
+
+        [Theory]
+        [InlineData(EventTypes.ContractCreatedEvent)]
+        [InlineData(EventTypes.ContractUpdatedEvent)]
+        public void ContractNotFound(string eventType)
+        {
+            var contractId = Guid.NewGuid();
+            this.Given(g => _ContractApiFixture.GivenTheContractDoesNotExist(contractId))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
+                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_ContractApiFixture.ReceivedCorrelationIds))
+                .Then(t => _steps.ThenAContractNotFoundExceptionIsThrown(contractId))
+                .BDDfy();
+        }
+        
+        [Theory]
+        [InlineData(EventTypes.ContractCreatedEvent)]
+        [InlineData(EventTypes.ContractUpdatedEvent)]
+        public void AssetNotFound(string eventType)
+        {
+            var contractId = Guid.NewGuid();
+            var assetId = Guid.NewGuid();
+            this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
+                .And(g => _AssetApiFixture.GivenTheAssetDoesNotExist(assetId))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
+                .Then(t => _steps.ThenAnAssetNotFoundExceptionIsThrown(assetId))
+                .BDDfy();
+        }
+
+        [Theory]
+        [InlineData(EventTypes.ContractCreatedEvent)]
+        [InlineData(EventTypes.ContractUpdatedEvent)]
+        public void ContractAddedToAsset(string eventType)
+        {
+            var contractId = Guid.NewGuid();
+            var assetId = Guid.NewGuid();
+            this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
+                .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
+                .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
+                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContract(_AssetApiFixture.ResponseObject, 
+                    _ContractApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
+                .BDDfy();
+        }
+    }
+}

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -59,7 +59,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                 .Then(t => _steps.ThenAContractNotFoundExceptionIsThrown(contractId))
                 .BDDfy();
         }
-        
+
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]
@@ -85,7 +85,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
                 .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
-                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContract(_AssetApiFixture.ResponseObject, 
+                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContract(_AssetApiFixture.ResponseObject,
                     _ContractApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();
         }

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.73.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.74.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -236,7 +236,7 @@ namespace HousingSearchListener.V1.Factories
                 assetContract.IsApproved = asset.AssetContract.IsApproved;
                 assetContract.ApprovalDate = asset.AssetContract.ApprovalDate;
                 assetContract.StartDate = asset.AssetContract.StartDate;
-                
+
                 foreach (var charge in asset.AssetContract.Charges)
                 {
                     var queryableCharge = new QueryableCharges

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -165,6 +165,7 @@ namespace HousingSearchListener.V1.Factories
             QueryableAssetLocation assetLocation = new QueryableAssetLocation();
             QueryableAssetContract assetContract = new QueryableAssetContract();
             List<QueryableCharges> queryableCharges = new List<QueryableCharges>();
+            List<QueryableRelatedPeople> queryableRelatedPeople = new List<QueryableRelatedPeople>();
 
             queryableAsset.Id = asset.Id.ToString();
             queryableAsset.AssetId = asset.AssetId;
@@ -230,17 +231,38 @@ namespace HousingSearchListener.V1.Factories
             if (asset.AssetContract != null)
             {
                 assetContract.Id = asset.AssetContract.Id;
+                assetContract.TargetId = asset.AssetContract.TargetId;
+                assetContract.TargetType = asset.AssetContract.TargetType;
+                assetContract.IsApproved = asset.AssetContract.IsApproved;
+                assetContract.ApprovalDate = asset.AssetContract.ApprovalDate;
+                assetContract.StartDate = asset.AssetContract.StartDate;
+                
                 foreach (var charge in asset.AssetContract.Charges)
                 {
-                    QueryableCharges queryableCharge = new QueryableCharges();
-                    queryableCharge.Id = charge.Id;
-                    queryableCharge.Type = charge.Type;
-                    queryableCharge.SubType = charge.SubType;
-                    queryableCharge.Frequency = charge.Frequency;
-                    queryableCharge.Amount = charge.Amount;
+                    var queryableCharge = new QueryableCharges
+                    {
+                        Id = charge.Id,
+                        Type = charge.Type,
+                        SubType = charge.SubType,
+                        Frequency = charge.Frequency,
+                        Amount = charge.Amount
+                    };
                     queryableCharges.Add(queryableCharge);
                 }
                 assetContract.Charges = queryableCharges;
+                
+                foreach (var relatedPerson in asset.AssetContract.RelatedPeople)
+                {
+                    var queryableRelatedPerson = new QueryableRelatedPeople
+                    {
+                        Id = relatedPerson.Id,
+                        Type = relatedPerson.Type,
+                        SubType = relatedPerson.SubType,
+                        Name = relatedPerson.Name
+                    };
+                    queryableRelatedPeople.Add(queryableRelatedPerson);
+                }
+                assetContract.RelatedPeople = queryableRelatedPeople;
                 queryableAsset.AssetContract = assetContract;
             }
 

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -250,7 +250,7 @@ namespace HousingSearchListener.V1.Factories
                     queryableCharges.Add(queryableCharge);
                 }
                 assetContract.Charges = queryableCharges;
-                
+
                 foreach (var relatedPerson in asset.AssetContract.RelatedPeople)
                 {
                     var queryableRelatedPerson = new QueryableRelatedPeople

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -86,7 +86,7 @@ namespace HousingSearchListener.V1.UseCase
 
                 asset.AssetContract.Charges = charges;
             }
-            
+
             if (contract.RelatedPeople.Any())
             {
                 _logger.LogInformation($"{contract.RelatedPeople.Count()} related people found.");
@@ -107,7 +107,7 @@ namespace HousingSearchListener.V1.UseCase
 
                 asset.AssetContract.RelatedPeople = relatedPeople;
             }
-            
+
             // 4. Update the indexes
             await UpdateAssetIndexAsync(asset);
         }


### PR DESCRIPTION
## Link to JIRA ticket
https://hackney.atlassian.net/browse/TS-1501

## Describe this PR

### *What is the problem we're trying to solve*

TA officers need to be able to see the data about contracts alongside asset data so that they can see the data they need to make a contract approval.

This PR relates to changes required to populate the asset contract with additional fields that are to be used either for querying the contract in the case of `isApproved`, or for display purposes in the case of the other fields.

A related [change](https://github.com/LBHackney-IT/housing-search-api/pull/231) is for querying the asset data using the new `isApproved` field.

### *What changes have we introduced*

- additional fields added to `AssetContract`
- new E2E tests covering `AddOrUpdateContractInAssetUseCase`