### PR TITLE
TS-1528 Fix related people and rates handling in asset contract

### DIFF
--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -1,17 +1,17 @@
 ﻿using AutoFixture;
 using FluentAssertions;
+using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
+using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using Hackney.Shared.HousingSearch.Gateways.Models.Tenures;
 using HousingSearchListener.V1.Domain.Tenure;
+using HousingSearchListener.V1.Domain.Transaction;
 using HousingSearchListener.V1.Factories;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using HousingSearchListener.V1.Domain.Transaction;
 using Xunit;
 using Person = HousingSearchListener.V1.Domain.Person.Person;
 using Tenure = HousingSearchListener.V1.Domain.Person.Tenure;
-using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
-using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 
 namespace HousingSearchListener.Tests.V1.Factories
 {
@@ -193,6 +193,28 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.AssetLocation.FloorNo.Should().Be(domainAsset.AssetLocation.FloorNo);
             result.ParentAssetIds.Should().Be(domainAsset.ParentAssetIds);
             result.RootAsset.Should().Be(domainAsset.RootAsset);
+        }
+
+        [Fact]
+        public void CreateAssetCanHandleNullAssetContractCharges()
+        {
+            var domainAsset = _fixture.Create<QueryableAsset>();
+            domainAsset.AssetContract.Charges = null;
+
+            var result = _sut.CreateAsset(domainAsset);
+
+            result.AssetContract.Charges.Should().BeNull();
+        }
+
+        [Fact]
+        public void CreateAssetCanHandleNullAssetContractRelatedPeople()
+        {
+            var domainAsset = _fixture.Create<QueryableAsset>();
+            domainAsset.AssetContract.RelatedPeople = null;
+
+            var result = _sut.CreateAsset(domainAsset);
+
+            result.AssetContract.RelatedPeople.Should().BeNull();
         }
     }
 }

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -237,32 +237,39 @@ namespace HousingSearchListener.V1.Factories
                 assetContract.ApprovalDate = asset.AssetContract.ApprovalDate;
                 assetContract.StartDate = asset.AssetContract.StartDate;
 
-                foreach (var charge in asset.AssetContract.Charges)
+                if (asset.AssetContract.Charges != null)
                 {
-                    var queryableCharge = new QueryableCharges
+                    foreach (var charge in asset.AssetContract.Charges)
                     {
-                        Id = charge.Id,
-                        Type = charge.Type,
-                        SubType = charge.SubType,
-                        Frequency = charge.Frequency,
-                        Amount = charge.Amount
-                    };
-                    queryableCharges.Add(queryableCharge);
+                        var queryableCharge = new QueryableCharges
+                        {
+                            Id = charge.Id,
+                            Type = charge.Type,
+                            SubType = charge.SubType,
+                            Frequency = charge.Frequency,
+                            Amount = charge.Amount
+                        };
+                        queryableCharges.Add(queryableCharge);
+                    }
+                    assetContract.Charges = queryableCharges;
                 }
-                assetContract.Charges = queryableCharges;
 
-                foreach (var relatedPerson in asset.AssetContract.RelatedPeople)
+                if (asset.AssetContract.RelatedPeople != null)
                 {
-                    var queryableRelatedPerson = new QueryableRelatedPeople
+                    foreach (var relatedPerson in asset.AssetContract.RelatedPeople)
                     {
-                        Id = relatedPerson.Id,
-                        Type = relatedPerson.Type,
-                        SubType = relatedPerson.SubType,
-                        Name = relatedPerson.Name
-                    };
-                    queryableRelatedPeople.Add(queryableRelatedPerson);
+                        var queryableRelatedPerson = new QueryableRelatedPeople
+                        {
+                            Id = relatedPerson.Id,
+                            Type = relatedPerson.Type,
+                            SubType = relatedPerson.SubType,
+                            Name = relatedPerson.Name
+                        };
+                        queryableRelatedPeople.Add(queryableRelatedPerson);
+                    }
+                    assetContract.RelatedPeople = queryableRelatedPeople;
                 }
-                assetContract.RelatedPeople = queryableRelatedPeople;
+
                 queryableAsset.AssetContract = assetContract;
             }
 


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1528](https://hackney.atlassian.net/browse/TS-1528)

## Describe this PR

### *What is the problem we're trying to solve*

When contract is initially created against asset in Book Temporary Accommodation it won't have the related people (`Asset.AssetContract.RelatedPeople`) or charges (`Asset.AssetContract.Charges`) set against it. Listener is using the same use case for creating and updating a contract for asset and expects them to be in place from the first creation.

However in BTA app those values will never be initially populated when the listener handles the first `ContractCreated` event, so the current implementation causes an exception to be thrown and the update not getting added to the `assets` index.

### *What changes have we introduced*

Add null checks for both `RelatedPeople` and `Charges` to ensure the index is updated with the rest of the values regardles of whether those two values are currently present. Please note the changes to usings are purely as a result of formatting.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Look at refactoring the `AddOrUpdateContractInAssetUseCase` since it's doing a lot of work that should be the responsibility of the CreateAsset ES entity factrory.


[TS-1528]: https://hackney.atlassian.net/browse/TS-1528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ