### PR TITLE
TS-1528: Update Contract Status to AssetContract

### DIFF
--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.74.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.75.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -234,6 +234,7 @@ namespace HousingSearchListener.V1.Factories
                 assetContract.TargetId = asset.AssetContract.TargetId;
                 assetContract.TargetType = asset.AssetContract.TargetType;
                 assetContract.IsApproved = asset.AssetContract.IsApproved;
+                assetContract.IsActive = asset.AssetContract.IsActive;
                 assetContract.ApprovalDate = asset.AssetContract.ApprovalDate;
                 assetContract.StartDate = asset.AssetContract.StartDate;
 

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -61,6 +61,7 @@ namespace HousingSearchListener.V1.UseCase
                 TargetId = contract.TargetId,
                 TargetType = contract.TargetType,
                 IsApproved = contract.IsApproved,
+                IsActive = contract.IsActive,
                 ApprovalDate = contract.ApprovalDate,
                 StartDate = contract.StartDate
             };


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1528

## Describe this PR

### *What is the problem we're trying to solve*

On BTA, contracts that are inactive and not approved are being displayed on the contracts worktray. To avoid this, we need to expose whether the contract is active or not on the AssetContract subentity in the Housing Search. 
We have deployed a new package version for this to be saved ([PR here](https://github.com/LBHackney-IT/housing-search-shared/pull/80)).
This PR is for the Contract status to be picked up by the listener and put into the AssetContract, so that then we can use it as a filter. It's essentially just extending [this previous PR](https://github.com/LBHackney-IT/housing-search-listener/pull/124/) by 1 more parameter.

### *What changes have we introduced*

Updated package version and added one parameter


### *Follow up actions after merging PR*

Following this, there will be a PR on the API as well
