### PR TITLE
TS-1610: Add new ApprovalStatus field on AssetContract

### DIFF
--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.75.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.76.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -234,6 +234,7 @@ namespace HousingSearchListener.V1.Factories
                 assetContract.TargetId = asset.AssetContract.TargetId;
                 assetContract.TargetType = asset.AssetContract.TargetType;
                 assetContract.IsApproved = asset.AssetContract.IsApproved;
+                assetContract.ApprovalStatus = asset.AssetContract.ApprovalStatus;
                 assetContract.IsActive = asset.AssetContract.IsActive;
                 assetContract.ApprovalDate = asset.AssetContract.ApprovalDate;
                 assetContract.StartDate = asset.AssetContract.StartDate;

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -61,6 +61,7 @@ namespace HousingSearchListener.V1.UseCase
                 TargetId = contract.TargetId,
                 TargetType = contract.TargetType,
                 IsApproved = contract.IsApproved,
+                ApprovalStatus = contract.ApprovalStatus,
                 IsActive = contract.IsActive,
                 ApprovalDate = contract.ApprovalDate,
                 StartDate = contract.StartDate


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1610

## Describe this PR

### *What is the problem we're trying to solve*

BTA users want to be able to reset the contract approval status of an updated approved contract so that it can be submitted for reapproval. This calls for changing from a boolean value to an enum in the Contracts, to account for more than two possible statuses. We need this field to be picked up bi the Listener so that we can retrieve it with the API
We haven't removed the `isApproved` flag yet so that the FE can continue to function until we introduce the new field there too.

### *What changes have we introduced*

Updated Hackney.Shared.HousingSearch package version
New field in EntityFactory and usecase.

### *Follow up actions after merging PR*

Update the API.