### PR TITLE
TS-1614: Adding data about the end of an assetContract

### DIFF
--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.78" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.79.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -233,6 +233,8 @@ namespace HousingSearchListener.V1.Factories
                 assetContract.Id = asset.AssetContract.Id;
                 assetContract.TargetId = asset.AssetContract.TargetId;
                 assetContract.TargetType = asset.AssetContract.TargetType;
+                assetContract.EndDate = asset.AssetContract.EndDate;
+                assetContract.EndReason = asset.AssetContract.EndReason;
                 assetContract.IsApproved = asset.AssetContract.IsApproved;
                 assetContract.ApprovalStatus = asset.AssetContract.ApprovalStatus;
                 assetContract.ApprovalStatusReason = asset.AssetContract.ApprovalStatusReason;

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -61,6 +61,8 @@ namespace HousingSearchListener.V1.UseCase
                 TargetId = contract.TargetId,
                 TargetType = contract.TargetType,
                 IsApproved = contract.IsApproved,
+                EndDate = contract.EndDate,
+                EndReason = contract.EndReason,
                 ApprovalStatus = contract.ApprovalStatus,
                 ApprovalStatusReason = contract.ApprovalStatusReason,
                 IsActive = contract.IsActive,


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1614

## Describe this PR

### *What is the problem we're trying to solve*

BTA users need a way to cancel invalid contracts (contracts opened in error) so that approval will no longer be required and no payment will be made to agent/landlord.
To do so, we need to see data about when and why a Contract was ended in the Asset information, as it will inform the decision about display a Contract for approval on BTA.

### *What changes have we introduced*

Shared package version update, factory and usecase update.

### *Follow up actions after merging PR*

Updating the API