### PR TITLE
TS-1746: Update shared package version to have ApprovalStatus as a string

### DIFF
--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.79.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.80.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1746

## Describe this PR

### *What is the problem we're trying to solve*

We need for ApprovalStatus to be set as a string in the Housing Search world to avoid de/serialisation issues and receive it as a string (as opposed to the current integer) in the Housing Search API response

### *What changes have we introduced*

Upgraded package version.

### *Follow up actions after merging PR*

Update API.