### PR TITLE
TS-1631: Display multiple pending contracts for the same property

### DIFF
--- a/HousingSearchListener.Tests/ElasticSearchFixture.cs
+++ b/HousingSearchListener.Tests/ElasticSearchFixture.cs
@@ -188,6 +188,7 @@ namespace HousingSearchListener.Tests
                                   .With(x => x.Id, assetId)
                                   .With(x => x.AssetId, assetId)
                                   .With(x => x.Tenure, esAssetTenure)
+                                  .Without(x => x.AssetContracts)
                                   .Create();
             var request = new IndexRequest<QueryableAsset>(esAsset, IndexNameAssets);
             await ElasticSearchClient.IndexAsync(request).ConfigureAwait(false);

--- a/HousingSearchListener.Tests/ElasticSearchFixture.cs
+++ b/HousingSearchListener.Tests/ElasticSearchFixture.cs
@@ -265,7 +265,7 @@ namespace HousingSearchListener.Tests
                               .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-40).ToString(DateFormat))
                               .With(x => x.PersonTenureType, personType)
                               .With(x => x.IsResponsible, isResponsible)
-                              .CreateMany(1).ToList();
+                              .CreateMany(3).ToList();
             hms.Last().Id = personId;
 
             return _fixture.Build<QueryableTenure>()

--- a/HousingSearchListener.Tests/ElasticSearchFixture.cs
+++ b/HousingSearchListener.Tests/ElasticSearchFixture.cs
@@ -265,7 +265,7 @@ namespace HousingSearchListener.Tests
                               .With(x => x.DateOfBirth, DateTime.UtcNow.AddYears(-40).ToString(DateFormat))
                               .With(x => x.PersonTenureType, personType)
                               .With(x => x.IsResponsible, isResponsible)
-                              .CreateMany(3).ToList();
+                              .CreateMany(1).ToList();
             hms.Last().Id = personId;
 
             return _fixture.Build<QueryableTenure>()
@@ -293,13 +293,13 @@ namespace HousingSearchListener.Tests
 
         public async Task GivenAContractIsIndexed(string assetId, string contractId)
         {
-            var esAssetContract = _fixture.Build<QueryableAssetContract>()
+            var esAssetContracts = _fixture.Build<QueryableAssetContract>()
                                         .With(x => x.Id, contractId)
-                                        .Create();
+                                        .CreateMany(1);
             var esAsset = _fixture.Build<QueryableAsset>()
                                   .With(x => x.Id, assetId)
                                   .With(x => x.AssetId, assetId)
-                                  .With(x => x.AssetContract, esAssetContract)
+                                  .With(x => x.AssetContracts, esAssetContracts)
                                   .Create();
             var request = new IndexRequest<QueryableAsset>(esAsset, IndexNameAssets);
             await ElasticSearchClient.IndexAsync(request).ConfigureAwait(false);

--- a/HousingSearchListener.Tests/FixtureConstants.cs
+++ b/HousingSearchListener.Tests/FixtureConstants.cs
@@ -20,7 +20,7 @@
         public static string ProcessesApiRoute => "http://localhost:5578/api/v1/processes/";
         public static string ProcessesApiToken => "sdjkhfgsdkjfgsdjfgh";
 
-        public static string ContractsApiRoute => "http://localhost:5978/api/v1/contracts/";
+        public static string ContractsApiRoute => "http://localhost:5978/api/v1/";
         public static string ContractsApiToken => "sdjkhfgsdkjfgsdjfgh";
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
@@ -36,10 +36,8 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
         {
 
             ResponseObject = _fixture.Build<QueryableAsset>()
-                                    .Without(x => x.AssetContracts)
                                     .With(x => x.Id, id.ToString())
                                     .Create();
-
 
             return ResponseObject;
         }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
@@ -1,9 +1,9 @@
 ﻿using AutoFixture;
 using Hackney.Core.Testing.Shared.E2E;
-using Hackney.Shared.HousingSearch.Domain.Asset;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
@@ -38,14 +38,18 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
                   .With(ch => ch.Frequency, "1")
                   .CreateMany(1).ToList();
 
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                                    .With(c => c.TargetId, id.ToString())
+                                    .With(c => c.TargetType, "asset")
+                                    .With(c => c.Charges, charges)
+                                    .CreateMany(1)
+                                    .ToList();
+
             ResponseObject = _fixture.Build<QueryableAsset>()
-                                     .With(x => x.Id, id.ToString())
-                                     .With(x => x.AssetContract, _fixture.Build<QueryableAssetContract>()
-                                         .With(c => c.TargetId, id.ToString())
-                                         .With(c => c.TargetType, "asset")
-                                         .With(c => c.Charges, charges)
-                                         .Create())
-                                     .Create();
+                                    .With(x => x.Id, id.ToString())
+                                    .With(x => x.AssetContracts, contracts)
+                                    .Create();
+
 
             return ResponseObject;
         }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
@@ -34,12 +34,9 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 
         public QueryableAsset GivenTheAssetExists(Guid id)
         {
-            var charges = _fixture.Build<QueryableCharges>()
-                  .With(ch => ch.Frequency, "1")
-                  .CreateMany(1).ToList();
-
 
             ResponseObject = _fixture.Build<QueryableAsset>()
+                                    .Without(x => x.AssetContracts)
                                     .With(x => x.Id, id.ToString())
                                     .Create();
 

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/AssetApiFixture.cs
@@ -38,16 +38,9 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
                   .With(ch => ch.Frequency, "1")
                   .CreateMany(1).ToList();
 
-            var contracts = _fixture.Build<QueryableAssetContract>()
-                                    .With(c => c.TargetId, id.ToString())
-                                    .With(c => c.TargetType, "asset")
-                                    .With(c => c.Charges, charges)
-                                    .CreateMany(1)
-                                    .ToList();
 
             ResponseObject = _fixture.Build<QueryableAsset>()
                                     .With(x => x.Id, id.ToString())
-                                    .With(x => x.AssetContracts, contracts)
                                     .Create();
 
 

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
@@ -2,6 +2,7 @@
 using Hackney.Core.Testing.Shared.E2E;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using System;
+using System.Collections.Generic;
 
 namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 {
@@ -39,5 +40,15 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 
             return ResponseObject;
         }
+        public List<Contract> GivenTheContractsExists(Guid contractId, Guid targetId)
+        {
+            ResponseObject = _fixture.Build<Contract>()
+                                     .With(x => x.Id, contractId.ToString())
+                                     .With(x => x.TargetId, targetId.ToString())
+                                     .With(x => x.TargetType, "asset")
+                                     .Create();
+
+            return new List<Contract>{ResponseObject};
+        }        
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
@@ -40,25 +40,5 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 
             return ResponseObject;
         }
-        public Contract GivenTheContractsExists(Guid contractId, Guid targetId)
-        {
-            ResponseObject = _fixture.Build<Contract>()
-                                     .With(x => x.Id, contractId.ToString())
-                                     .With(x => x.TargetId, targetId.ToString())
-                                     .With(x => x.TargetType, "asset")
-                                     .Create();
-
-            return ResponseObject;
-        }
-        public Contract GivenOneContractExists(Guid contractId, Guid targetId)
-        {
-            ResponseObject = _fixture.Build<Contract>()
-                                     .With(x => x.Id, contractId.ToString())
-                                     .With(x => x.TargetId, targetId.ToString())
-                                     .With(x => x.TargetType, "asset")
-                                     .Create();
-
-            return ResponseObject;
-        }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
@@ -40,7 +40,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 
             return ResponseObject;
         }
-        public List<Contract> GivenTheContractsExists(Guid contractId, Guid targetId)
+        public Contract GivenTheContractsExists(Guid contractId, Guid targetId)
         {
             ResponseObject = _fixture.Build<Contract>()
                                      .With(x => x.Id, contractId.ToString())
@@ -48,7 +48,17 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
                                      .With(x => x.TargetType, "asset")
                                      .Create();
 
-            return new List<Contract>{ResponseObject};
-        }        
+            return ResponseObject;
+        }
+        public Contract GivenOneContractExists(Guid contractId, Guid targetId)
+        {
+            ResponseObject = _fixture.Build<Contract>()
+                                     .With(x => x.Id, contractId.ToString())
+                                     .With(x => x.TargetId, targetId.ToString())
+                                     .With(x => x.TargetType, "asset")
+                                     .Create();
+
+            return ResponseObject;
+        }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/ContractApiFixture .cs
@@ -2,7 +2,6 @@
 using Hackney.Core.Testing.Shared.E2E;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using System;
-using System.Collections.Generic;
 
 namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 {

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -1,0 +1,42 @@
+﻿using AutoFixture;
+using Hackney.Core.Testing.Shared.E2E;
+using Hackney.Shared.HousingSearch.Domain.Contract;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
+{
+    public class MultipleContractApiFixture : BaseApiFixture<IEnumerable<Contract>>
+    {
+        private readonly Fixture _fixture = new Fixture();
+
+        public MultipleContractApiFixture()
+            : base(FixtureConstants.ContractsApiRoute, FixtureConstants.ContractsApiToken)
+        {
+            Environment.SetEnvironmentVariable("ContractApiUrl", FixtureConstants.ContractsApiRoute);
+            Environment.SetEnvironmentVariable("ContractApiToken", FixtureConstants.ContractsApiToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                base.Dispose(disposing);
+            }
+        }
+
+
+        public IEnumerable<Contract> GivenTheContractsExists(Guid contractId, Guid targetId)
+        {
+            ResponseObject = _fixture.Build<Contract>()
+                                     .With(x => x.Id, contractId.ToString())
+                                     .With(x => x.TargetId, targetId.ToString())
+                                     .With(x => x.TargetType, "asset")
+                                     .CreateMany(1)
+                                     .ToList();
+
+            return ResponseObject;
+        }
+    }
+}

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -35,20 +35,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
                                      .With(x => x.TargetId, targetId.ToString())
                                      .With(x => x.TargetType, "asset")
                                      .Create();
-
-            //return ResponseObject.ToList();     BEWARE OF THE LIES! THIS DOES NOT IN FACT MAKE A LIST -__-  
             return new List<Contract> { ResponseObject };
-
-
-            /*var singleContract = new Contract    
-            {
-                Id = contractId.ToString(),
-                TargetId = contractId.ToString(),
-                TargetType = "asset"
-            };
-
-            return new List<Contract> {singleContract};*/
-
         }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -27,7 +27,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
         }
 
 
-        public IEnumerable<Contract> GivenTheContractsExists(Guid contractId, Guid targetId)
+        public IEnumerable<Contract> GivenMultipleContractsExist(Guid contractId, Guid targetId)
         {
             ResponseObject = _fixture.Build<Contract>()
                                      .With(x => x.Id, contractId.ToString())

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -4,6 +4,7 @@ using Hackney.Shared.HousingSearch.Domain.Contract;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 {
@@ -27,16 +28,27 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
         }
 
 
-        public IEnumerable<Contract> GivenMultipleContractsExist(Guid contractId, Guid targetId)
+        public List<Contract> GivenMultipleContractsExist(Guid contractId, Guid targetId)
         {
-            ResponseObject = _fixture.Build<Contract>()
+            var ResponseObject = _fixture.Build<Contract>()
                                      .With(x => x.Id, contractId.ToString())
                                      .With(x => x.TargetId, targetId.ToString())
                                      .With(x => x.TargetType, "asset")
-                                     .CreateMany(1)
-                                     .ToList();
+                                     .Create();
 
-            return ResponseObject;
+            //return ResponseObject.ToList();     BEWARE OF THE LIES! THIS DOES NOT IN FACT MAKE A LIST -__-  
+            return new List<Contract> { ResponseObject };
+
+
+            /*var singleContract = new Contract    
+            {
+                Id = contractId.ToString(),
+                TargetId = contractId.ToString(),
+                TargetType = "asset"
+            };
+
+            return new List<Contract> {singleContract};*/
+
         }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -17,9 +17,9 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
             _eventType = EventTypes.ContractCreatedEvent;
         }
 
-        public async Task WhenTheFunctionIsTriggered(Guid contractId, string eventType)
+        public async Task WhenTheFunctionIsTriggered(Guid contractId, string eventType, string targetType)
         {
-            var eventMsg = CreateEvent(contractId, eventType);
+            var eventMsg = CreateEvent(contractId, eventType, targetType);
             await TriggerFunction(CreateMessage(eventMsg));
         }
 

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using EventTypes = HousingSearchListener.V1.Boundary.EventTypes;
+using System.Linq;
 
 namespace HousingSearchListener.Tests.V1.E2ETests.Steps
 {
@@ -43,7 +44,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
                                        .ConfigureAwait(false);
 
             var assetInIndex = result.Source;
-            assetInIndex.AssetContract.Should().BeEquivalentTo(contract);
+            assetInIndex.AssetContracts.First().Should().BeEquivalentTo(contract);
         }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using EventTypes = HousingSearchListener.V1.Boundary.EventTypes;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace HousingSearchListener.Tests.V1.E2ETests.Steps
 {
@@ -37,6 +38,12 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
             (_lastException as EntityNotFoundException<QueryableAsset>).Id.Should().Be(id);
         }
 
+        public void ThenAnArgumentExceptionIsThrown()
+        {
+            _lastException.Should().NotBeNull();
+            _lastException.Should().BeOfType(typeof(ArgumentException));
+        }
+
         public async Task ThenTheAssetInTheIndexIsUpdatedWithTheContract(
             QueryableAsset asset, Contract contract, IElasticClient esClient)
         {
@@ -45,6 +52,16 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
 
             var assetInIndex = result.Source;
             assetInIndex.AssetContracts.First().Should().BeEquivalentTo(contract);
+        }
+
+        public async Task ThenTheAssetInTheIndexIsUpdatedWithTheContracts(
+            QueryableAsset asset, IEnumerable<Contract> contracts, IElasticClient esClient)
+        {
+            var result = await esClient.GetAsync<QueryableAsset>(asset.Id, g => g.Index("assets"))
+                                       .ConfigureAwait(false);
+
+            var assetInIndex = result.Source;
+            assetInIndex.AssetContracts.Should().BeEquivalentTo(contracts);
         }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
@@ -47,15 +47,21 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
 
         protected EntityEventSns CreateEvent(Guid entityId, string eventType, string targetId = null)
         {
-            return _fixture.Build<EntityEventSns>()
-                           .With(x => x.EntityId, entityId)
-                           .With(x => x.EventType, eventType)
-                           .With(x => x.CorrelationId, _correlationId)
-                           .With(x => x.EventData, new EventData
-                           {
-                               NewData = new { Id = targetId }
-                           })
-                            .Create();
+            var EntityEventBuilder = _fixture.Build<EntityEventSns>()
+                                .With(x => x.EntityId, entityId)
+                                .With(x => x.EventType, eventType)
+                                .With(x => x.CorrelationId, _correlationId);
+
+            //had to make this conditional as it was messing with preexisting tests
+            if (targetId != null)
+            {
+                EntityEventBuilder = EntityEventBuilder.With(x => x.EventData, new EventData
+                {
+                    NewData = new { Id = targetId }
+                });
+            }
+
+            return EntityEventBuilder.Create();
         }
 
         protected SQSEvent.SQSMessage CreateMessage(Guid personId)

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
@@ -45,7 +45,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
         }
 
 
-        protected EntityEventSns CreateEvent(Guid entityId, string eventType, string targetId = "")
+        protected EntityEventSns CreateEvent(Guid entityId, string eventType, string targetId = null)
         {
             return _fixture.Build<EntityEventSns>()
                            .With(x => x.EntityId, entityId)

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
@@ -45,13 +45,17 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
         }
 
 
-        protected EntityEventSns CreateEvent(Guid entityId, string eventType)
+        protected EntityEventSns CreateEvent(Guid entityId, string eventType, string targetId = "")
         {
             return _fixture.Build<EntityEventSns>()
                            .With(x => x.EntityId, entityId)
                            .With(x => x.EventType, eventType)
                            .With(x => x.CorrelationId, _correlationId)
-                           .Create();
+                           .With(x => x.EventData, new EventData
+                           {
+                               NewData = new { Id = targetId }
+                           })
+                            .Create();
         }
 
         protected SQSEvent.SQSMessage CreateMessage(Guid personId)

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -71,8 +71,21 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             var assetId = Guid.NewGuid();
             this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetDoesNotExist(assetId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, ""))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
                 .Then(t => _steps.ThenAnAssetNotFoundExceptionIsThrown(assetId))
+                .BDDfy();
+        }
+
+        [Theory]
+        [InlineData(EventTypes.ContractCreatedEvent)]
+        [InlineData(EventTypes.ContractUpdatedEvent)]
+        public void NullAssetIdInMessage(string eventType)
+        {
+            var contractId = Guid.NewGuid();
+            var assetId = Guid.NewGuid();
+            this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, null))
+                .Then(t => _steps.ThenAnArgumentExceptionIsThrown())
                 .BDDfy();
         }
 
@@ -83,13 +96,12 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         {
             var contractId = Guid.NewGuid();
             var assetId = Guid.NewGuid();
-            this.Given(g => _ContractsApiFixture.GivenTheContractsExists(contractId, assetId))
+            this.Given(g => _ContractsApiFixture.GivenMultipleContractsExist(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
                 .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
-                /*.Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContract(_AssetApiFixture.ResponseObject,
-                    _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))*/
-                .Then("blah")
+                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContracts(_AssetApiFixture.ResponseObject,
+                    _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();
         }
     }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -17,7 +17,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         private readonly ElasticSearchFixture _esFixture;
         private readonly AssetApiFixture _AssetApiFixture;
         private readonly ContractApiFixture _ContractApiFixture;
-
+        private readonly MultipleContractApiFixture _ContractsApiFixture;
         private readonly AddOrUpdateContractOnAssetTestsSteps _steps;
 
         public AddOrUpdateContractOnAssetTests(ElasticSearchFixture esFixture)
@@ -25,6 +25,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             _esFixture = esFixture;
             _AssetApiFixture = new AssetApiFixture();
             _ContractApiFixture = new ContractApiFixture();
+            _ContractsApiFixture = new MultipleContractApiFixture();
 
             _steps = new AddOrUpdateContractOnAssetTestsSteps();
         }
@@ -42,6 +43,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             {
                 _AssetApiFixture.Dispose();
                 _ContractApiFixture.Dispose();
+                _ContractsApiFixture.Dispose();
 
                 _disposed = true;
             }
@@ -81,12 +83,13 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         {
             var contractId = Guid.NewGuid();
             var assetId = Guid.NewGuid();
-            this.Given(g => _ContractApiFixture.GivenTheContractsExists(contractId, assetId))
+            this.Given(g => _ContractsApiFixture.GivenTheContractsExists(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
                 .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
-                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContract(_AssetApiFixture.ResponseObject,
-                    _ContractApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
+                /*.Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContract(_AssetApiFixture.ResponseObject,
+                    _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))*/
+                .Then("blah")
                 .BDDfy();
         }
     }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -81,7 +81,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         {
             var contractId = Guid.NewGuid();
             var assetId = Guid.NewGuid();
-            this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
+            this.Given(g => _ContractApiFixture.GivenTheContractsExists(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
                 .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -54,7 +54,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         {
             var contractId = Guid.NewGuid();
             this.Given(g => _ContractApiFixture.GivenTheContractDoesNotExist(contractId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, "assetId.ToString()"))
                 .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_ContractApiFixture.ReceivedCorrelationIds))
                 .Then(t => _steps.ThenAContractNotFoundExceptionIsThrown(contractId))
                 .BDDfy();
@@ -69,7 +69,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             var assetId = Guid.NewGuid();
             this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetDoesNotExist(assetId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, ""))
                 .Then(t => _steps.ThenAnAssetNotFoundExceptionIsThrown(assetId))
                 .BDDfy();
         }
@@ -84,7 +84,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
                 .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContract(_AssetApiFixture.ResponseObject,
                     _ContractApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -49,18 +49,6 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             }
         }
 
-        [Theory]
-        [InlineData(EventTypes.ContractCreatedEvent)]
-        [InlineData(EventTypes.ContractUpdatedEvent)]
-        public void ContractNotFound(string eventType)
-        {
-            var contractId = Guid.NewGuid();
-            this.Given(g => _ContractApiFixture.GivenTheContractDoesNotExist(contractId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, "assetId.ToString()"))
-                .Then(t => _steps.ThenTheCorrelationIdWasUsedInTheApiCall(_ContractApiFixture.ReceivedCorrelationIds))
-                .Then(t => _steps.ThenAContractNotFoundExceptionIsThrown(contractId))
-                .BDDfy();
-        }
 
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -169,15 +169,18 @@ namespace HousingSearchListener.Tests.V1.Factories
               .CreateMany(1).ToList();
 
 
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                                    .With(c => c.TargetType, "asset")
+                                    .With(c => c.Charges, charges)
+                                    .CreateMany(1)
+                                    .ToList();
+
             var domainAsset = _fixture.Build<QueryableAsset>()
             .With(x => x.AssetAddress, _fixture.Create<QueryableAssetAddress>())
             .With(x => x.AssetCharacteristics, _fixture.Create<QueryableAssetCharacteristics>())
             .With(x => x.AssetManagement, _fixture.Create<QueryableAssetManagement>())
             .With(x => x.AssetLocation, _fixture.Create<QueryableAssetLocation>())
-            .With(x => x.AssetContract, _fixture.Build<QueryableAssetContract>()
-                .With(c => c.TargetType, "asset")
-                .With(c => c.Charges, charges)
-                .Create())
+            .With(x => x.AssetContracts, contracts)
             .Create();
 
             var result = _sut.CreateAsset(domainAsset);
@@ -198,23 +201,30 @@ namespace HousingSearchListener.Tests.V1.Factories
         [Fact]
         public void CreateAssetCanHandleNullAssetContractCharges()
         {
-            var domainAsset = _fixture.Create<QueryableAsset>();
-            domainAsset.AssetContract.Charges = null;
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                        .With(c => c.TargetType, "asset")
+                        .CreateMany(1)
+                        .ToList();
+
+            var domainAsset = _fixture.Build<QueryableAsset>()
+                            .With(a => a.AssetContracts, contracts).Create();
+
+            domainAsset.AssetContracts.First().Charges = null;
 
             var result = _sut.CreateAsset(domainAsset);
 
-            result.AssetContract.Charges.Should().BeNull();
+            result.AssetContracts.First().Charges.Should().BeNull();
         }
 
         [Fact]
         public void CreateAssetCanHandleNullAssetContractRelatedPeople()
         {
             var domainAsset = _fixture.Create<QueryableAsset>();
-            domainAsset.AssetContract.RelatedPeople = null;
+            domainAsset.AssetContracts.First().RelatedPeople = null;
 
             var result = _sut.CreateAsset(domainAsset);
 
-            result.AssetContract.RelatedPeople.Should().BeNull();
+            result.AssetContracts.First().RelatedPeople.Should().BeNull();
         }
     }
 }

--- a/HousingSearchListener.Tests/V1/UseCase/AddOrUpdateContractInAssetUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/AddOrUpdateContractInAssetUseCaseTests.cs
@@ -10,6 +10,7 @@ using HousingSearchListener.V1.Infrastructure.Exceptions;
 using HousingSearchListener.V1.UseCase;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Nest;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,9 +75,15 @@ namespace HousingSearchListener.Tests.V1.UseCase
 
         private QueryableAsset CreateAsset(Guid entityId)
         {
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                                    .With(c => c.TargetType, "asset")
+                                    .CreateMany(1)
+                                    .ToList();
             return _fixture.Build<QueryableAsset>()
                            .With(x => x.Id, entityId.ToString())
+                           .With(x => x.AssetContracts, contracts)
                            .Create();
+
         }
 
         private Contract CreateContract(Guid entityId)
@@ -95,19 +102,18 @@ namespace HousingSearchListener.Tests.V1.UseCase
                 OldData = new Dictionary<string, object> { { "asset", oldData } },
                 NewData = new Dictionary<string, object> { { "asset", newData } }
             };
-
             Guid? contractId = null;
             if (hasChanges)
             {
                 if (added is null)
                 {
                     var changed = newData;
-                    changed.AssetContract.Charges.First().Amount = 90;
+                    changed.AssetContracts.First().Charges.First().Amount = 90;
                     contractId = Guid.Parse(changed.Id);
                 }
                 else
                 {
-                    newData.AssetContract.Charges = added.Charges;
+                    newData.AssetContracts.First().Charges = added.Charges;
                     contractId = Guid.Parse(added.Id);
                 }
             }
@@ -125,7 +131,7 @@ namespace HousingSearchListener.Tests.V1.UseCase
         {
             esAsset.Should().BeEquivalentTo(_esEntityFactory.CreateAsset(asset));
 
-            var newContract = esAsset.AssetContract;
+            var newContract = esAsset.AssetContracts.First();
             newContract.Should().NotBeNull();
             newContract.TargetId.Should().Be(contract.TargetId);
             newContract.TargetType.Should().Be(contract.TargetType);

--- a/HousingSearchListener.Tests/V1/UseCase/IndexCreateAssetUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/IndexCreateAssetUseCaseTests.cs
@@ -58,13 +58,16 @@ namespace HousingSearchListener.Tests.V1.UseCase
               .With(ch => ch.Frequency, "1")
               .CreateMany(1).ToList();
 
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                        .With(c => c.TargetId, entityId.ToString())
+                        .With(c => c.TargetType, "asset")
+                        .With(c => c.Charges, charges)
+                        .CreateMany(1)
+                        .ToList();
+
             return _fixture.Build<QueryableAsset>()
                                      .With(x => x.Id, entityId.ToString())
-                                     .With(x => x.AssetContract, _fixture.Build<QueryableAssetContract>()
-                                         .With(c => c.TargetId, entityId.ToString())
-                                         .With(c => c.TargetType, "asset")
-                                         .With(c => c.Charges, charges)
-                                         .Create())
+                                     .With(x => x.AssetContracts, contracts)
                                      .Create();
         }
 

--- a/HousingSearchListener.Tests/V1/UseCase/UpdateAssetUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/UpdateAssetUseCaseTests.cs
@@ -58,17 +58,21 @@ namespace HousingSearchListener.Tests.V1.UseCase
 
         private QueryableAsset CreateAsset(Guid entityId)
         {
+
             var charges = _fixture.Build<QueryableCharges>()
               .With(ch => ch.Frequency, "1")
               .CreateMany(1).ToList();
 
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                        .With(c => c.TargetId, entityId.ToString())
+                        .With(c => c.TargetType, "asset")
+                        .With(c => c.Charges, charges)
+                        .CreateMany(1)
+                        .ToList();
+
             return _fixture.Build<QueryableAsset>()
                                      .With(x => x.Id, entityId.ToString())
-                                     .With(x => x.AssetContract, _fixture.Build<QueryableAssetContract>()
-                                         .With(c => c.TargetId, entityId.ToString())
-                                         .With(c => c.TargetType, "asset")
-                                         .With(c => c.Charges, charges)
-                                         .Create())
+                                     .With(x => x.AssetContracts, contracts)
                                      .Create();
         }
 

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.82.0-feat-ts-1631-0002" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.82.0" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/HousingSearchListener.csproj
+++ b/HousingSearchListener/HousingSearchListener.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
-    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.81.0" />
+    <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.82.0-feat-ts-1631-0002" />
     <PackageReference Include="Hackney.Shared.Processes" Version="0.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -163,7 +163,7 @@ namespace HousingSearchListener.V1.Factories
             QueryableAssetCharacteristics assetCharacteristics = new QueryableAssetCharacteristics();
             QueryableAssetManagement assetManagement = new QueryableAssetManagement();
             QueryableAssetLocation assetLocation = new QueryableAssetLocation();
-            QueryableAssetContract assetContract = new QueryableAssetContract();
+            List<QueryableAssetContract> queryableAssetContracts = new List<QueryableAssetContract>();
             List<QueryableCharges> queryableCharges = new List<QueryableCharges>();
             List<QueryableRelatedPeople> queryableRelatedPeople = new List<QueryableRelatedPeople>();
 
@@ -228,53 +228,61 @@ namespace HousingSearchListener.V1.Factories
                 queryableAsset.AssetManagement = assetManagement;
             }
 
-            if (asset.AssetContract != null)
+            if (asset.AssetContracts != null)
             {
-                assetContract.Id = asset.AssetContract.Id;
-                assetContract.TargetId = asset.AssetContract.TargetId;
-                assetContract.TargetType = asset.AssetContract.TargetType;
-                assetContract.EndDate = asset.AssetContract.EndDate;
-                assetContract.EndReason = asset.AssetContract.EndReason;
-                assetContract.ApprovalStatus = asset.AssetContract.ApprovalStatus;
-                assetContract.ApprovalStatusReason = asset.AssetContract.ApprovalStatusReason;
-                assetContract.IsActive = asset.AssetContract.IsActive;
-                assetContract.ApprovalDate = asset.AssetContract.ApprovalDate;
-                assetContract.StartDate = asset.AssetContract.StartDate;
-
-                if (asset.AssetContract.Charges != null)
+                foreach (var contract in asset.AssetContracts)
                 {
-                    foreach (var charge in asset.AssetContract.Charges)
-                    {
-                        var queryableCharge = new QueryableCharges
-                        {
-                            Id = charge.Id,
-                            Type = charge.Type,
-                            SubType = charge.SubType,
-                            Frequency = charge.Frequency,
-                            Amount = charge.Amount
-                        };
-                        queryableCharges.Add(queryableCharge);
-                    }
-                    assetContract.Charges = queryableCharges;
-                }
 
-                if (asset.AssetContract.RelatedPeople != null)
-                {
-                    foreach (var relatedPerson in asset.AssetContract.RelatedPeople)
+                    var queryableContract = new QueryableAssetContract
                     {
-                        var queryableRelatedPerson = new QueryableRelatedPeople
-                        {
-                            Id = relatedPerson.Id,
-                            Type = relatedPerson.Type,
-                            SubType = relatedPerson.SubType,
-                            Name = relatedPerson.Name
-                        };
-                        queryableRelatedPeople.Add(queryableRelatedPerson);
-                    }
-                    assetContract.RelatedPeople = queryableRelatedPeople;
-                }
+                        Id = contract.Id,
+                        TargetId = contract.TargetId,
+                        TargetType = contract.TargetType,
+                        EndDate = contract.EndDate,
+                        EndReason = contract.EndReason,
+                        ApprovalStatus = contract.ApprovalStatus,
+                        ApprovalStatusReason = contract.ApprovalStatusReason,
+                        IsActive = contract.IsActive,
+                        ApprovalDate = contract.ApprovalDate,
+                        StartDate = contract.StartDate
+                    };
 
-                queryableAsset.AssetContract = assetContract;
+                    queryableAssetContracts.Add(queryableContract);
+
+                    if (contract.Charges != null)
+                    {
+                        foreach (var charge in contract.Charges)
+                        {
+                            var queryableCharge = new QueryableCharges
+                            {
+                                Id = charge.Id,
+                                Type = charge.Type,
+                                SubType = charge.SubType,
+                                Frequency = charge.Frequency,
+                                Amount = charge.Amount
+                            };
+                            queryableCharges.Add(queryableCharge);
+                        }
+                        queryableContract.Charges = queryableCharges;
+                    }
+
+                    if (contract.RelatedPeople != null)
+                    {
+                        foreach (var relatedPerson in contract.RelatedPeople)
+                        {
+                            var queryableRelatedPerson = new QueryableRelatedPeople
+                            {
+                                Id = relatedPerson.Id,
+                                Type = relatedPerson.Type,
+                                SubType = relatedPerson.SubType,
+                                Name = relatedPerson.Name
+                            };
+                            queryableRelatedPeople.Add(queryableRelatedPerson);
+                        }
+                        queryableContract.RelatedPeople = queryableRelatedPeople;
+                    }
+                }
+                queryableAsset.AssetContracts = queryableAssetContracts;
             }
 
             if (asset.AssetLocation != null)

--- a/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
@@ -29,10 +29,11 @@ namespace HousingSearchListener.V1.Gateway
             return await _apiGateway.GetByIdAsync<Contract>(route, id, correlationId);
         }
         [LogCall]
-        public async Task<PagedResult<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
+        public async Task<Contract> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
         {
-            var route = $"{_apiGateway.ApiRoute}?targetId={targetId}&targetType=asset";
-            var apiCall = await _apiGateway.GetByIdAsync<PagedResult<Contract>>(route, targetId, correlationId);
+            var route = $"{_apiGateway.ApiRoute}/contracts?targetId={targetId}&targetType=asset";
+            //var route = $"{_apiGateway.ApiRoute}/contracts/oof";
+            var apiCall = await _apiGateway.GetByIdAsync<Contract>(route, targetId, correlationId);
             return apiCall;
         }
     }

--- a/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
@@ -34,7 +34,6 @@ namespace HousingSearchListener.V1.Gateway
         public async Task<List<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
         {
             var route = $"{_apiGateway.ApiRoute}/contracts?targetId={targetId}&targetType=asset";
-            //var route = $"{_apiGateway.ApiRoute}/contracts/oof";
             var apiCall = await _apiGateway.GetByIdAsync<List<Contract>>(route, targetId, correlationId);
             return apiCall;
         }

--- a/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
@@ -4,7 +4,6 @@ using Hackney.Core.Logging;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using HousingSearchListener.V1.Gateway.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HousingSearchListener.V1.Gateway
@@ -12,15 +11,15 @@ namespace HousingSearchListener.V1.Gateway
     public class ContractApiGateway : IContractApiGateway
     {
         private const string ApiName = "ContractApi";
-        private const string AssetApiUrl = "ContractApiUrl";
-        private const string AssetApiToken = "ContractApiToken";
+        private const string ContractApiUrl = "ContractApiUrl";
+        private const string ContractApiToken = "ContractApiToken";
 
         private readonly IApiGateway _apiGateway;
 
         public ContractApiGateway(IApiGateway apiGateway)
         {
             _apiGateway = apiGateway;
-            _apiGateway.Initialise(ApiName, AssetApiUrl, AssetApiToken);
+            _apiGateway.Initialise(ApiName, ContractApiUrl, ContractApiToken);
         }
 
         [LogCall]
@@ -32,8 +31,9 @@ namespace HousingSearchListener.V1.Gateway
         [LogCall]
         public async Task<PagedResult<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
         {
-            var route = $"{_apiGateway.ApiRoute}/contracts?targetId={targetId}";
-            return await _apiGateway.GetByIdAsync<PagedResult<Contract>>(route, targetId, correlationId);
+            var route = $"{_apiGateway.ApiRoute}?targetId={targetId}&targetType=asset";
+            var apiCall = await _apiGateway.GetByIdAsync<PagedResult<Contract>>(route, targetId, correlationId);
+            return apiCall;
         }
     }
 }

--- a/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
@@ -1,8 +1,10 @@
-﻿using Hackney.Core.Http;
+﻿using Hackney.Core.DynamoDb;
+using Hackney.Core.Http;
 using Hackney.Core.Logging;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using HousingSearchListener.V1.Gateway.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HousingSearchListener.V1.Gateway
@@ -26,6 +28,12 @@ namespace HousingSearchListener.V1.Gateway
         {
             var route = $"{_apiGateway.ApiRoute}/contracts/{id}";
             return await _apiGateway.GetByIdAsync<Contract>(route, id, correlationId);
+        }
+        [LogCall]
+        public async Task<PagedResult<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
+        {
+            var route = $"{_apiGateway.ApiRoute}/contracts?targetId={targetId}";
+            return await _apiGateway.GetByIdAsync<PagedResult<Contract>>(route, targetId, correlationId);
         }
     }
 }

--- a/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
@@ -4,6 +4,8 @@ using Hackney.Core.Logging;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using HousingSearchListener.V1.Gateway.Interfaces;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HousingSearchListener.V1.Gateway
@@ -29,11 +31,11 @@ namespace HousingSearchListener.V1.Gateway
             return await _apiGateway.GetByIdAsync<Contract>(route, id, correlationId);
         }
         [LogCall]
-        public async Task<Contract> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
+        public async Task<List<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
         {
             var route = $"{_apiGateway.ApiRoute}/contracts?targetId={targetId}&targetType=asset";
             //var route = $"{_apiGateway.ApiRoute}/contracts/oof";
-            var apiCall = await _apiGateway.GetByIdAsync<Contract>(route, targetId, correlationId);
+            var apiCall = await _apiGateway.GetByIdAsync<List<Contract>>(route, targetId, correlationId);
             return apiCall;
         }
     }

--- a/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
@@ -9,7 +9,7 @@ namespace HousingSearchListener.V1.Gateway.Interfaces
     public interface IContractApiGateway
     {
         Task<Contract> GetContractByIdAsync(Guid entityId, Guid correlationId);
-        Task<Contract> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId);
+        Task<List<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId);
 
     }
 }

--- a/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
@@ -1,5 +1,7 @@
-﻿using Hackney.Shared.HousingSearch.Domain.Contract;
+﻿using Hackney.Core.DynamoDb;
+using Hackney.Shared.HousingSearch.Domain.Contract;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HousingSearchListener.V1.Gateway.Interfaces
@@ -7,5 +9,7 @@ namespace HousingSearchListener.V1.Gateway.Interfaces
     public interface IContractApiGateway
     {
         Task<Contract> GetContractByIdAsync(Guid entityId, Guid correlationId);
+        Task<PagedResult<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId);
+
     }
 }

--- a/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
@@ -9,7 +9,7 @@ namespace HousingSearchListener.V1.Gateway.Interfaces
     public interface IContractApiGateway
     {
         Task<Contract> GetContractByIdAsync(Guid entityId, Guid correlationId);
-        Task<PagedResult<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId);
+        Task<Contract> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId);
 
     }
 }

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -70,13 +70,16 @@ namespace HousingSearchListener.V1.UseCase
             // 3. Get all contracts from Contract API
             var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false) ?? throw new EntityNotFoundException<List<Hackney.Shared.HousingSearch.Domain.Contract.Contract>>(assetId);
 
+
+            var allFilteredContracts = allContracts.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
+
             // 4. Cycle over them to retrieve data (will need filters)
-            if (allContracts.Any())
+            if (allFilteredContracts.Any())
             {
-                _logger.LogInformation($"{allContracts.Count()} contracts found.");
+                _logger.LogInformation($"{allFilteredContracts.Count()} contracts found.");
 
                 var assetContracts = new List<QueryableAssetContract>();
-                foreach (var assetContract in allContracts)
+                foreach (var assetContract in allFilteredContracts)
                 {
                     var queryableAssetContract = new QueryableAssetContract
                     {

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -61,6 +61,8 @@ namespace HousingSearchListener.V1.UseCase
 
             var asset = await _assetApiGateway.GetAssetByIdAsync(assetId, message.CorrelationId)
                                                 .ConfigureAwait(false) ?? throw new EntityNotFoundException<QueryableAsset>(assetId);
+                                                
+            var call = await _contractApiGateway.GetContractByIdAsync(assetId, message.CorrelationId).ConfigureAwait(false);
 
             // 3. Get all contracts from Contract API
             var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false);

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -61,14 +61,14 @@ namespace HousingSearchListener.V1.UseCase
 
             var asset = await _assetApiGateway.GetAssetByIdAsync(assetId, message.CorrelationId)
                                                 .ConfigureAwait(false) ?? throw new EntityNotFoundException<QueryableAsset>(assetId);
-                                                
-            var call = await _contractApiGateway.GetContractByIdAsync(assetId, message.CorrelationId).ConfigureAwait(false);
+
+            var OGCall = await _contractApiGateway.GetContractByIdAsync(assetId, message.CorrelationId).ConfigureAwait(false);
 
             // 3. Get all contracts from Contract API
             var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false);
 
             // 4. Cycle over them to retrieve data (will need filters)
-            if (allContracts.Results.Any())
+            /*if (allContracts.Results.Any())
             {
                 _logger.LogInformation($"{allContracts.Results.Count()} contracts found.");
 
@@ -136,7 +136,7 @@ namespace HousingSearchListener.V1.UseCase
                 asset.AssetContracts = assetContracts;
                 // 5. Update the indexes
                 await UpdateAssetIndexAsync(asset);
-            }
+            }*/
         }
         private async Task UpdateAssetIndexAsync(QueryableAsset asset)
         {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1631

## Describe this PR

### *What is the problem we're trying to solve*

On BTA, the Contracts approval Worktray relies on the Housing Search system to display what contract belongs to which asset. Currently, only the latest contract is saved by the Listener, however, in some instances, BTA users will need to approve more than one contract on the same property. This happens, for example, if a tenant moves in and out of the property in a matter of days: since the contract approval is not guaranteed to be done on a daily basis, those contracts would not be approved in time.
This PR follows the one on the shared package found [here](https://github.com/LBHackney-IT/housing-search-shared/pull/89).
The changes in this and the following API PR will move `AssetContract ` property on the `Asset `entity from a single one to a list of `AssetContracts`.

### *What changes have we introduced*

Factories, Gateway and Usecase changes, plus test adaptation. In particular, in the Usecase the contracts are now returned calling a different Contracts API endpoint with the targetId/targetType combo to return multiple contracts.

### *Follow up actions after merging PR*

Updates to the API.