### PR TITLE
TS-1631: Add message logging upon CU Contract operations

### DIFF
--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -50,10 +50,12 @@ namespace HousingSearchListener.V1.UseCase
                 throw new ArgumentException($"No charges of Types asset found for contract id: {contract.Id}");
             _logger.LogInformation($"Contract with id {contract.Id} found. Now fetching Asset {contract.TargetId}");
             */
+            _logger.LogInformation($"message.EventData.NewData follows[{message.EventData.NewData}]");
 
             //New process to handle multiple contracts
             //1. Get Asset data from message
             var assetMessageData = GetAssetDataFromEventData(message.EventData.NewData);
+            _logger.LogInformation($"assetMessageData: [{assetMessageData}]");
 
             if (assetMessageData.Id == null)
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1631  

## Describe this PR

As per the previous PRs for BTA, we're now trying add all contracts for an asset in the AssetContract section.
We were moving from the assumption the message would contain the assetId, however we're struggling to retrieve it and the listeners throws an exception.
This log will enable us to view what the message contains and act accordingly.