### PR TITLE
TS-1631 - Return to retrieving assetId from contract

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -67,19 +67,6 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]
-        public void NullAssetIdInMessage(string eventType)
-        {
-            var contractId = Guid.NewGuid();
-            var assetId = Guid.NewGuid();
-            this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, null))
-                .Then(t => _steps.ThenAnArgumentExceptionIsThrown())
-                .BDDfy();
-        }
-
-        [Theory]
-        [InlineData(EventTypes.ContractCreatedEvent)]
-        [InlineData(EventTypes.ContractUpdatedEvent)]
         public void ContractAddedToAsset(string eventType)
         {
             var contractId = Guid.NewGuid();

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -50,10 +50,12 @@ namespace HousingSearchListener.V1.UseCase
                 throw new ArgumentException($"No charges of Types asset found for contract id: {contract.Id}");
             _logger.LogInformation($"Contract with id {contract.Id} found. Now fetching Asset {contract.TargetId}");
             */
+            _logger.LogInformation($"message.EventData.NewData follows[{message.EventData.NewData}]");
 
             //New process to handle multiple contracts
             //1. Get Asset data from message
             var assetMessageData = GetAssetDataFromEventData(message.EventData.NewData);
+            _logger.LogInformation($"assetMessageData: [{assetMessageData}]");
 
             if (assetMessageData.Id == null)
             {

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -40,7 +40,7 @@ namespace HousingSearchListener.V1.UseCase
         {
             if (message is null) throw new ArgumentNullException(nameof(message));
 
-            /* 1. Get Contract from Contract service API
+            // 1. Turns out, I still need to get Contract from Contract service API
             var contract = await _contractApiGateway.GetContractByIdAsync(message.EntityId, message.CorrelationId)
                                                 .ConfigureAwait(false);
             if (contract is null) throw new EntityNotFoundException<Contract>(message.EntityId);
@@ -49,20 +49,12 @@ namespace HousingSearchListener.V1.UseCase
             if (!contract.TargetType.ToLower().Equals("asset"))
                 throw new ArgumentException($"No charges of Types asset found for contract id: {contract.Id}");
             _logger.LogInformation($"Contract with id {contract.Id} found. Now fetching Asset {contract.TargetId}");
-            */
-            _logger.LogInformation($"message.EventData.NewData follows[{message.EventData.NewData}]");
+
 
             //New process to handle multiple contracts
             //1. Get Asset data from message
-            var assetMessageData = GetAssetDataFromEventData(message.EventData.NewData);
-            _logger.LogInformation($"assetMessageData: [{assetMessageData}]");
 
-            if (assetMessageData.Id == null)
-            {
-                throw new ArgumentException($"No assetId was found in the message");
-            }
-
-            var assetId = Guid.Parse(assetMessageData.Id);
+            var assetId = Guid.Parse(contract.TargetId);
 
             // 2. Get asset from Asset API
 
@@ -153,10 +145,6 @@ namespace HousingSearchListener.V1.UseCase
                 throw new ArgumentException($"No asset found in index with id: {asset.Id}");
             esAsset = _esEntityFactory.CreateAsset(asset);
             await _esGateway.IndexAsset(esAsset);
-        }
-        private static Asset GetAssetDataFromEventData(object data)
-        {
-            return (data is Asset) ? data as Asset : ObjectFactory.ConvertFromObject<Asset>(data);
         }
     }
 }

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -40,7 +40,7 @@ namespace HousingSearchListener.V1.UseCase
         {
             if (message is null) throw new ArgumentNullException(nameof(message));
 
-            // 1. Turns out, I still need to get Contract from Contract service API
+            // 1. Turns out, I still need to get Contract from Contract service API, as the message doesn't contain the assetId as we assumed
             var contract = await _contractApiGateway.GetContractByIdAsync(message.EntityId, message.CorrelationId)
                                                 .ConfigureAwait(false);
             if (contract is null) throw new EntityNotFoundException<Contract>(message.EntityId);
@@ -52,7 +52,7 @@ namespace HousingSearchListener.V1.UseCase
 
 
             //New process to handle multiple contracts
-            //1. Get Asset data from message
+            //1. Get Asset data from contract
 
             var assetId = Guid.Parse(contract.TargetId);
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1631

## Describe this PR

This PR partially reverts the [previous one](https://github.com/LBHackney-IT/housing-search-listener/pull/137), where we were operating on the assumption the SNS message would contain the assetId. As it turns out, this is not the case. So we're going back to obtaining the assetId from the contract itself. The rest of the logic is unchanged from the previous PR.