### PR TITLE
TS-1631: AssetContracts: handle PagedResult

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -1,10 +1,11 @@
 ﻿using AutoFixture;
+using Hackney.Core.DynamoDb;
 using Hackney.Core.Testing.Shared.E2E;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
+
 
 namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 {
@@ -28,14 +29,14 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
         }
 
 
-        public List<Contract> GivenMultipleContractsExist(Guid contractId, Guid targetId)
+        public PagedResult<Contract> GivenMultipleContractsAreReturned(Guid contractId, Guid targetId)
         {
             var ResponseObject = _fixture.Build<Contract>()
                                      .With(x => x.Id, contractId.ToString())
                                      .With(x => x.TargetId, targetId.ToString())
                                      .With(x => x.TargetType, "asset")
-                                     .Create();
-            return new List<Contract> { ResponseObject };
+                                     .CreateMany(1).ToList();
+            return new PagedResult<Contract> { Results = ResponseObject };
         }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -71,7 +71,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         {
             var contractId = Guid.NewGuid();
             var assetId = Guid.NewGuid();
-            this.Given(g => _ContractsApiFixture.GivenMultipleContractsExist(contractId, assetId))
+            this.Given(g => _ContractsApiFixture.GivenMultipleContractsAreReturned(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
                 .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))

--- a/HousingSearchListener.Tests/V1/UseCase/AddOrUpdateContractInAssetUseCaseTests.cs
+++ b/HousingSearchListener.Tests/V1/UseCase/AddOrUpdateContractInAssetUseCaseTests.cs
@@ -159,6 +159,18 @@ namespace HousingSearchListener.Tests.V1.UseCase
         }
 
         [Fact]
+        public void ProcessMessageAsyncTestGetContractsByAssetIdExceptionThrown()
+        {
+            var exMsg = "This is an error";
+            _mockContractApi.Setup(x => x.GetContractsByAssetIdAsync(_messageCreated.EntityId, _messageCreated.CorrelationId))
+                                       .ThrowsAsync(new Exception(exMsg));
+
+            Func<Task> func = async () => await _sut.ProcessMessageAsync(_messageCreated).ConfigureAwait(false);
+            func.Should().ThrowAsync<EntityNotFoundException<Contract>>();
+        }
+
+
+        [Fact]
         public void ProcessMessageAsyncTestGetContractReturnsNullThrows()
         {
             _mockContractApi.Setup(x => x.GetContractByIdAsync(_messageCreated.EntityId, _messageCreated.CorrelationId))

--- a/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/ContractApiGateway.cs
@@ -4,8 +4,6 @@ using Hackney.Core.Logging;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using HousingSearchListener.V1.Gateway.Interfaces;
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HousingSearchListener.V1.Gateway
@@ -31,10 +29,10 @@ namespace HousingSearchListener.V1.Gateway
             return await _apiGateway.GetByIdAsync<Contract>(route, id, correlationId);
         }
         [LogCall]
-        public async Task<List<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
+        public async Task<PagedResult<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId)
         {
             var route = $"{_apiGateway.ApiRoute}/contracts?targetId={targetId}&targetType=asset";
-            var apiCall = await _apiGateway.GetByIdAsync<List<Contract>>(route, targetId, correlationId);
+            var apiCall = await _apiGateway.GetByIdAsync<PagedResult<Contract>>(route, targetId, correlationId);
             return apiCall;
         }
     }

--- a/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
+++ b/HousingSearchListener/V1/Gateway/Interfaces/IContractApiGateway.cs
@@ -1,7 +1,6 @@
 ﻿using Hackney.Core.DynamoDb;
 using Hackney.Shared.HousingSearch.Domain.Contract;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace HousingSearchListener.V1.Gateway.Interfaces
@@ -9,7 +8,7 @@ namespace HousingSearchListener.V1.Gateway.Interfaces
     public interface IContractApiGateway
     {
         Task<Contract> GetContractByIdAsync(Guid entityId, Guid correlationId);
-        Task<List<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId);
+        Task<PagedResult<Contract>> GetContractsByAssetIdAsync(Guid targetId, Guid correlationId);
 
     }
 }

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -64,10 +64,9 @@ namespace HousingSearchListener.V1.UseCase
             // 3. Get all contracts from Contract API
             var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false) ?? throw new EntityNotFoundException<List<Hackney.Shared.HousingSearch.Domain.Contract.Contract>>(assetId);
 
+            var allFilteredContracts = allContracts.Results.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
 
-            var allFilteredContracts = allContracts.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
-
-            // 4. Cycle over them to retrieve data (will need filters)
+            // 4. Cycle over them to retrieve data 
             if (allFilteredContracts.Any())
             {
                 _logger.LogInformation($"{allFilteredContracts.Count()} contracts found.");


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1631

## Describe this PR
When we are retrieving multiple contracts from the dedicated endpoint on the Contract API, those results are paged, something I (sillily) hadn't taken into account. At the moment, the Listener fails when retrieving those results as it expects a list of contracts. This PR aims to remediate that.