### PR TITLE
TS-1923: Always update the asset in the index, regardless of contract status

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -1,52 +1,48 @@
-﻿using AutoFixture;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture;
 using Hackney.Core.DynamoDb;
 using Hackney.Core.Testing.Shared.E2E;
 using Hackney.Shared.HousingSearch.Domain.Contract;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
-namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
+namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures;
+
+public class MultipleContractApiFixture : BaseApiFixture<IEnumerable<Contract>>
 {
-    public class MultipleContractApiFixture : BaseApiFixture<IEnumerable<Contract>>
+    private readonly Fixture _fixture = new();
+
+    public MultipleContractApiFixture()
+        : base(FixtureConstants.ContractsApiRoute, FixtureConstants.ContractsApiToken)
     {
-        private readonly Fixture _fixture = new Fixture();
+        Environment.SetEnvironmentVariable("ContractApiUrl", FixtureConstants.ContractsApiRoute);
+        Environment.SetEnvironmentVariable("ContractApiToken", FixtureConstants.ContractsApiToken);
+    }
 
-        public MultipleContractApiFixture()
-            : base(FixtureConstants.ContractsApiRoute, FixtureConstants.ContractsApiToken)
-        {
-            Environment.SetEnvironmentVariable("ContractApiUrl", FixtureConstants.ContractsApiRoute);
-            Environment.SetEnvironmentVariable("ContractApiToken", FixtureConstants.ContractsApiToken);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && !_disposed)
-            {
-                base.Dispose(disposing);
-            }
-        }
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !_disposed) base.Dispose(disposing);
+    }
 
 
-        public PagedResult<Contract> GivenMultipleContractsAreReturned(Guid contractId, Guid targetId)
-        {
-            var ResponseObject = _fixture.Build<Contract>()
-                                     .With(x => x.Id, contractId.ToString())
-                                     .With(x => x.TargetId, targetId.ToString())
-                                     .With(x => x.TargetType, "asset")
-                                     .CreateMany(1).ToList();
-            return new PagedResult<Contract> { Results = ResponseObject };
-        }
-        
-        public PagedResult<Contract> GivenApprovedContractsAreReturned(Guid contractId, Guid targetId)
-        {
-            var ResponseObject = _fixture.Build<Contract>()
-                .With(x => x.Id, contractId.ToString())
-                .With(x => x.TargetId, targetId.ToString())
-                .With(x => x.TargetType, "asset")
-                .With(x => x.ApprovalStatus, "Approve")
-                .CreateMany(2).ToList();
-            return new PagedResult<Contract> { Results = ResponseObject };
-        }
+    public PagedResult<Contract> GivenMultipleContractsAreReturned(Guid contractId, Guid targetId)
+    {
+        var ResponseObject = _fixture.Build<Contract>()
+            .With(x => x.Id, contractId.ToString())
+            .With(x => x.TargetId, targetId.ToString())
+            .With(x => x.TargetType, "asset")
+            .CreateMany(1).ToList();
+        return new PagedResult<Contract> { Results = ResponseObject };
+    }
+
+    public PagedResult<Contract> GivenApprovedContractsAreReturned(Guid contractId, Guid targetId)
+    {
+        var ResponseObject = _fixture.Build<Contract>()
+            .With(x => x.Id, contractId.ToString())
+            .With(x => x.TargetId, targetId.ToString())
+            .With(x => x.TargetType, "asset")
+            .With(x => x.ApprovalStatus, "Approved")
+            .CreateMany(1).ToList();
+        return new PagedResult<Contract> { Results = ResponseObject };
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-
 namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 {
     public class MultipleContractApiFixture : BaseApiFixture<IEnumerable<Contract>>
@@ -36,6 +35,17 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
                                      .With(x => x.TargetId, targetId.ToString())
                                      .With(x => x.TargetType, "asset")
                                      .CreateMany(1).ToList();
+            return new PagedResult<Contract> { Results = ResponseObject };
+        }
+        
+        public PagedResult<Contract> GivenApprovedContractsAreReturned(Guid contractId, Guid targetId)
+        {
+            var ResponseObject = _fixture.Build<Contract>()
+                .With(x => x.Id, contractId.ToString())
+                .With(x => x.TargetId, targetId.ToString())
+                .With(x => x.TargetType, "asset")
+                .With(x => x.ApprovalStatus, "Approve")
+                .CreateMany(2).ToList();
             return new PagedResult<Contract> { Results = ResponseObject };
         }
     }

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -70,6 +70,6 @@ public class AddOrUpdateContractOnAssetTestsSteps : BaseSteps
             .ConfigureAwait(false);
 
         var assetInIndex = result.Source;
-        assetInIndex.AssetContracts.Should().BeEquivalentTo(new List<Contract>());
+        assetInIndex.AssetContracts.Should().BeNull();
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -63,5 +63,14 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
             var assetInIndex = result.Source;
             assetInIndex.AssetContracts.Should().BeEquivalentTo(contracts);
         }
+        
+        public async Task ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(QueryableAsset asset, IElasticClient esClient)
+        {
+            var result = await esClient.GetAsync<QueryableAsset>(asset.Id, g => g.Index("assets"))
+                                       .ConfigureAwait(false);
+
+            var assetInIndex = result.Source;
+            assetInIndex.AssetContracts.Should().BeEquivalentTo(new List<Contract>());
+        }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -1,99 +1,99 @@
-﻿using HousingSearchListener.Tests.V1.E2ETests.Fixtures;
+﻿using System;
+using HousingSearchListener.Tests.V1.E2ETests.Fixtures;
 using HousingSearchListener.Tests.V1.E2ETests.Steps;
 using HousingSearchListener.V1.Boundary;
-using System;
 using TestStack.BDDfy;
 using Xunit;
 
-namespace HousingSearchListener.Tests.V1.E2ETests.Stories
+namespace HousingSearchListener.Tests.V1.E2ETests.Stories;
+
+[Story(
+    AsA = "SQS Contract Listener",
+    IWant = "a function to process the Contract added or updated messages",
+    SoThat = "The Contract details are updated on the Asset in the index")]
+[Collection("ElasticSearch collection")]
+public class AddOrUpdateContractOnAssetTests : IDisposable
 {
-    [Story(
-        AsA = "SQS Contract Listener",
-        IWant = "a function to process the Contract added or updated messages",
-        SoThat = "The Contract details are updated on the Asset in the index")]
-    [Collection("ElasticSearch collection")]
-    public class AddOrUpdateContractOnAssetTests : IDisposable
+    private readonly AssetApiFixture _AssetApiFixture;
+    private readonly ContractApiFixture _ContractApiFixture;
+    private readonly MultipleContractApiFixture _ContractsApiFixture;
+    private readonly ElasticSearchFixture _esFixture;
+    private readonly AddOrUpdateContractOnAssetTestsSteps _steps;
+
+    private bool _disposed;
+
+    public AddOrUpdateContractOnAssetTests(ElasticSearchFixture esFixture)
     {
-        private readonly ElasticSearchFixture _esFixture;
-        private readonly AssetApiFixture _AssetApiFixture;
-        private readonly ContractApiFixture _ContractApiFixture;
-        private readonly MultipleContractApiFixture _ContractsApiFixture;
-        private readonly AddOrUpdateContractOnAssetTestsSteps _steps;
+        _esFixture = esFixture;
+        _AssetApiFixture = new AssetApiFixture();
+        _ContractApiFixture = new ContractApiFixture();
+        _ContractsApiFixture = new MultipleContractApiFixture();
 
-        public AddOrUpdateContractOnAssetTests(ElasticSearchFixture esFixture)
+        _steps = new AddOrUpdateContractOnAssetTestsSteps();
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing && !_disposed)
         {
-            _esFixture = esFixture;
-            _AssetApiFixture = new AssetApiFixture();
-            _ContractApiFixture = new ContractApiFixture();
-            _ContractsApiFixture = new MultipleContractApiFixture();
+            _AssetApiFixture.Dispose();
+            _ContractApiFixture.Dispose();
+            _ContractsApiFixture.Dispose();
 
-            _steps = new AddOrUpdateContractOnAssetTestsSteps();
+            _disposed = true;
         }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        private bool _disposed;
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing && !_disposed)
-            {
-                _AssetApiFixture.Dispose();
-                _ContractApiFixture.Dispose();
-                _ContractsApiFixture.Dispose();
-
-                _disposed = true;
-            }
-        }
+    }
 
 
-        [Theory]
-        [InlineData(EventTypes.ContractCreatedEvent)]
-        [InlineData(EventTypes.ContractUpdatedEvent)]
-        public void AssetNotFound(string eventType)
-        {
-            var contractId = Guid.NewGuid();
-            var assetId = Guid.NewGuid();
-            this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
-                .And(g => _AssetApiFixture.GivenTheAssetDoesNotExist(assetId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
-                .Then(t => _steps.ThenAnAssetNotFoundExceptionIsThrown(assetId))
-                .BDDfy();
-        }
+    [Theory]
+    [InlineData(EventTypes.ContractCreatedEvent)]
+    [InlineData(EventTypes.ContractUpdatedEvent)]
+    public void AssetNotFound(string eventType)
+    {
+        var contractId = Guid.NewGuid();
+        var assetId = Guid.NewGuid();
+        this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
+            .And(g => _AssetApiFixture.GivenTheAssetDoesNotExist(assetId))
+            .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+            .Then(t => _steps.ThenAnAssetNotFoundExceptionIsThrown(assetId))
+            .BDDfy();
+    }
 
-        [Theory]
-        [InlineData(EventTypes.ContractCreatedEvent)]
-        [InlineData(EventTypes.ContractUpdatedEvent)]
-        public void ContractAddedToAsset(string eventType)
-        {
-            var contractId = Guid.NewGuid();
-            var assetId = Guid.NewGuid();
-            this.Given(g => _ContractsApiFixture.GivenMultipleContractsAreReturned(contractId, assetId))
-                .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
-                .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
-                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContracts(_AssetApiFixture.ResponseObject,
-                    _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
-                .BDDfy();
-        }
-        
-        [Theory]
-        [InlineData(EventTypes.ContractCreatedEvent)]
-        [InlineData(EventTypes.ContractUpdatedEvent)]
-        public void ContractNotAddedToAssetWhenNoUnapprovedContractsAreAvailable(string eventType)
-        {
-            var contractId = Guid.NewGuid();
-            var assetId = Guid.NewGuid();
-            this.Given(g => _ContractsApiFixture.GivenApprovedContractsAreReturned(contractId, assetId))
-                .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
-                .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
-                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(_AssetApiFixture.ResponseObject, 
-                    _esFixture.ElasticSearchClient))
-                .BDDfy();
-        }
+    [Theory]
+    [InlineData(EventTypes.ContractCreatedEvent)]
+    [InlineData(EventTypes.ContractUpdatedEvent)]
+    public void ContractAddedToAsset(string eventType)
+    {
+        var contractId = Guid.NewGuid();
+        var assetId = Guid.NewGuid();
+        this.Given(g => _ContractsApiFixture.GivenMultipleContractsAreReturned(contractId, assetId))
+            .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
+            .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
+            .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+            .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContracts(_AssetApiFixture.ResponseObject,
+                _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
+            .BDDfy();
+    }
+
+    [Theory]
+    [InlineData(EventTypes.ContractCreatedEvent)]
+    [InlineData(EventTypes.ContractUpdatedEvent)]
+    public void ContractNotAddedToAssetWhenNoUnapprovedContractsAreAvailable(string eventType)
+    {
+        var contractId = Guid.NewGuid();
+        var assetId = Guid.NewGuid();
+        this.Given(g => _ContractsApiFixture.GivenApprovedContractsAreReturned(contractId, assetId))
+            .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
+            .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
+            .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+            .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(_AssetApiFixture.ResponseObject,
+                _esFixture.ElasticSearchClient))
+            .BDDfy();
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -79,5 +79,21 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                     _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();
         }
+        
+        [Theory]
+        [InlineData(EventTypes.ContractCreatedEvent)]
+        [InlineData(EventTypes.ContractUpdatedEvent)]
+        public void ContractNotAddedToAssetWhenNoUnapprovedContractsAreAvailable(string eventType)
+        {
+            var contractId = Guid.NewGuid();
+            var assetId = Guid.NewGuid();
+            this.Given(g => _ContractsApiFixture.GivenApprovedContractsAreReturned(contractId, assetId))
+                .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
+                .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(_AssetApiFixture.ResponseObject, 
+                    _esFixture.ElasticSearchClient))
+                .BDDfy();
+        }
     }
 }

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -53,11 +53,9 @@ namespace HousingSearchListener.V1.UseCase
 
             //New process to handle multiple contracts
             //1. Get Asset data from contract
-
             var assetId = Guid.Parse(contract.TargetId);
 
             // 2. Get asset from Asset API
-
             var asset = await _assetApiGateway.GetAssetByIdAsync(assetId, message.CorrelationId)
                                                 .ConfigureAwait(false) ?? throw new EntityNotFoundException<QueryableAsset>(assetId);
 
@@ -65,77 +63,76 @@ namespace HousingSearchListener.V1.UseCase
             var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false) ?? throw new EntityNotFoundException<List<Hackney.Shared.HousingSearch.Domain.Contract.Contract>>(assetId);
 
             var allFilteredContracts = allContracts.Results.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
-
+            _logger.LogInformation($"{allFilteredContracts.Count()} contracts found.");
+            
             // 4. Cycle over them to retrieve data 
-            if (allFilteredContracts.Any())
+            var assetContracts = new List<QueryableAssetContract>(); 
+            foreach (var assetContract in allFilteredContracts)
             {
-                _logger.LogInformation($"{allFilteredContracts.Count()} contracts found.");
-
-                var assetContracts = new List<QueryableAssetContract>();
-                foreach (var assetContract in allFilteredContracts)
+                _logger.LogInformation($"Contract with id {assetContract.Id} being added to asset");
+                var queryableAssetContract = new QueryableAssetContract
                 {
-                    var queryableAssetContract = new QueryableAssetContract
-                    {
-                        Id = assetContract.Id,
-                        TargetId = assetContract.TargetId,
-                        TargetType = assetContract.TargetType,
-                        EndDate = assetContract.EndDate,
-                        EndReason = assetContract.EndReason,
-                        ApprovalStatus = assetContract.ApprovalStatus,
-                        ApprovalStatusReason = assetContract.ApprovalStatusReason,
-                        IsActive = assetContract.IsActive,
-                        ApprovalDate = assetContract.ApprovalDate,
-                        StartDate = assetContract.StartDate
-                    };
+                    Id = assetContract.Id,
+                    TargetId = assetContract.TargetId,
+                    TargetType = assetContract.TargetType,
+                    EndDate = assetContract.EndDate,
+                    EndReason = assetContract.EndReason,
+                    ApprovalStatus = assetContract.ApprovalStatus,
+                    ApprovalStatusReason = assetContract.ApprovalStatusReason,
+                    IsActive = assetContract.IsActive,
+                    ApprovalDate = assetContract.ApprovalDate,
+                    StartDate = assetContract.StartDate
+                };
 
-                    if (assetContract.Charges.Any())
-                    {
-                        _logger.LogInformation($"{assetContract.Charges.Count()} charges found.");
-                        var charges = new List<QueryableCharges>();
+                if (assetContract.Charges.Any())
+                {
+                    _logger.LogInformation($"{assetContract.Charges.Count()} charges found.");
+                    var charges = new List<QueryableCharges>();
 
-                        foreach (var charge in assetContract.Charges)
+                    foreach (var charge in assetContract.Charges)
+                    {
+                        _logger.LogInformation($"Charge with id {charge.Id} being added to asset with frequency {charge.Frequency}");
+                        var queryableCharge = new QueryableCharges
                         {
-                            _logger.LogInformation($"Charge with id {charge.Id} being added to asset with frequency {charge.Frequency}");
-                            var queryableCharge = new QueryableCharges
-                            {
-                                Id = charge.Id,
-                                Type = charge.Type,
-                                SubType = charge.SubType,
-                                Frequency = charge.Frequency,
-                                Amount = charge.Amount
-                            };
-                            charges.Add(queryableCharge);
-                        }
-
-                        queryableAssetContract.Charges = charges;
+                            Id = charge.Id,
+                            Type = charge.Type,
+                            SubType = charge.SubType,
+                            Frequency = charge.Frequency,
+                            Amount = charge.Amount
+                        };
+                        charges.Add(queryableCharge);
                     }
 
-                    if (assetContract.RelatedPeople.Any())
-                    {
-                        _logger.LogInformation($"{assetContract.RelatedPeople.Count()} related people found.");
-                        var relatedPeople = new List<QueryableRelatedPeople>();
-
-                        foreach (var relatedPerson in assetContract.RelatedPeople)
-                        {
-                            _logger.LogInformation($"Related person with id {relatedPerson.Id} being added to asset");
-                            var queryableRelatedPeople = new QueryableRelatedPeople
-                            {
-                                Id = relatedPerson.Id,
-                                Type = relatedPerson.Type,
-                                SubType = relatedPerson.SubType,
-                                Name = relatedPerson.Name,
-                            };
-                            relatedPeople.Add(queryableRelatedPeople);
-                        }
-
-                        queryableAssetContract.RelatedPeople = relatedPeople;
-                    }
-                    assetContracts.Add(queryableAssetContract);
+                    queryableAssetContract.Charges = charges;
                 }
-                asset.AssetContracts = assetContracts;
-                // 5. Update the indexes
-                await UpdateAssetIndexAsync(asset);
+
+                if (assetContract.RelatedPeople.Any())
+                {
+                    _logger.LogInformation($"{assetContract.RelatedPeople.Count()} related people found.");
+                    var relatedPeople = new List<QueryableRelatedPeople>();
+
+                    foreach (var relatedPerson in assetContract.RelatedPeople)
+                    {
+                        _logger.LogInformation($"Related person with id {relatedPerson.Id} being added to asset");
+                        var queryableRelatedPeople = new QueryableRelatedPeople
+                        {
+                            Id = relatedPerson.Id,
+                            Type = relatedPerson.Type,
+                            SubType = relatedPerson.SubType,
+                            Name = relatedPerson.Name,
+                        };
+                        relatedPeople.Add(queryableRelatedPeople);
+                    }
+
+                    queryableAssetContract.RelatedPeople = relatedPeople;
+                }
+                assetContracts.Add(queryableAssetContract);
             }
+            
+            asset.AssetContracts = assetContracts;
+            
+            // 5. Update the indexes
+            await UpdateAssetIndexAsync(asset);
         }
         private async Task UpdateAssetIndexAsync(QueryableAsset asset)
         {

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -1,6 +1,10 @@
-﻿using Hackney.Core.Logging;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hackney.Core.Logging;
 using Hackney.Core.Sns;
-using Hackney.Shared.Processes.Sns;
+using Hackney.Shared.HousingSearch.Domain.Asset;
 using Hackney.Shared.HousingSearch.Gateways.Models.Assets;
 using Hackney.Shared.HousingSearch.Gateways.Models.Contract;
 using HousingSearchListener.V1.Factories;
@@ -8,139 +12,140 @@ using HousingSearchListener.V1.Gateway.Interfaces;
 using HousingSearchListener.V1.Infrastructure.Exceptions;
 using HousingSearchListener.V1.UseCase.Interfaces;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using HousingSearchApi.V1.Factories;
-using Hackney.Shared.HousingSearch.Domain.Asset;
 
-namespace HousingSearchListener.V1.UseCase
+namespace HousingSearchListener.V1.UseCase;
+
+public class AddOrUpdateContractInAssetUseCase : IAddOrUpdateContractInAssetUseCase
 {
-    public class AddOrUpdateContractInAssetUseCase : IAddOrUpdateContractInAssetUseCase
+    private readonly IAssetApiGateway _assetApiGateway;
+    private readonly IContractApiGateway _contractApiGateway;
+    private readonly IESEntityFactory _esEntityFactory;
+    private readonly IEsGateway _esGateway;
+    private readonly ILogger<AddOrUpdateContractInAssetUseCase> _logger;
+
+    public AddOrUpdateContractInAssetUseCase(IEsGateway esGateway, IContractApiGateway contractApiGateway,
+        IAssetApiGateway assetApiGateway, IESEntityFactory esEntityFactory,
+        ILogger<AddOrUpdateContractInAssetUseCase> logger)
     {
-        private readonly ILogger<AddOrUpdateContractInAssetUseCase> _logger;
-        private readonly IEsGateway _esGateway;
-        private readonly IContractApiGateway _contractApiGateway;
-        private readonly IAssetApiGateway _assetApiGateway;
-        private readonly IESEntityFactory _esEntityFactory;
+        _esGateway = esGateway;
+        _contractApiGateway = contractApiGateway;
+        _assetApiGateway = assetApiGateway;
+        _esEntityFactory = esEntityFactory;
+        _logger = logger;
+    }
 
-        public AddOrUpdateContractInAssetUseCase(IEsGateway esGateway, IContractApiGateway contractApiGateway,
-            IAssetApiGateway assetApiGateway, IESEntityFactory esEntityFactory, ILogger<AddOrUpdateContractInAssetUseCase> logger)
+    [LogCall]
+    public async Task ProcessMessageAsync(EntityEventSns message)
+    {
+        if (message is null) throw new ArgumentNullException(nameof(message));
+
+        // 1. Turns out, I still need to get Contract from Contract service API, as the message doesn't contain the assetId as we assumed
+        var contract = await _contractApiGateway.GetContractByIdAsync(message.EntityId, message.CorrelationId)
+            .ConfigureAwait(false);
+        if (contract is null) throw new EntityNotFoundException<Contract>(message.EntityId);
+
+        // 2. Determine the Contract is for an Asset.
+        if (!contract.TargetType.ToLower().Equals("asset"))
+            throw new ArgumentException($"No charges of Types asset found for contract id: {contract.Id}");
+        _logger.LogInformation($"Contract with id {contract.Id} found. Now fetching Asset {contract.TargetId}");
+
+
+        //New process to handle multiple contracts
+        //1. Get Asset data from contract
+        var assetId = Guid.Parse(contract.TargetId);
+
+        // 2. Get asset from Asset API
+        var asset = await _assetApiGateway.GetAssetByIdAsync(assetId, message.CorrelationId)
+            .ConfigureAwait(false) ?? throw new EntityNotFoundException<QueryableAsset>(assetId);
+
+        // 3. Get all contracts from Contract API
+        var allContracts =
+            await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId)
+                .ConfigureAwait(false) ??
+            throw new EntityNotFoundException<List<Hackney.Shared.HousingSearch.Domain.Contract.Contract>>(assetId);
+
+        var allFilteredContracts = allContracts.Results.Where(x => x?.ApprovalStatus != "Approved")
+            .Where(x => x?.EndReason != "ContractNoLongerNeeded");
+        _logger.LogInformation($"{allFilteredContracts.Count()} contracts found.");
+
+        // 4. Cycle over them to retrieve data 
+        var assetContracts = new List<QueryableAssetContract>();
+        foreach (var assetContract in allFilteredContracts)
         {
-            _esGateway = esGateway;
-            _contractApiGateway = contractApiGateway;
-            _assetApiGateway = assetApiGateway;
-            _esEntityFactory = esEntityFactory;
-            _logger = logger;
-        }
-
-        [LogCall]
-        public async Task ProcessMessageAsync(EntityEventSns message)
-        {
-            if (message is null) throw new ArgumentNullException(nameof(message));
-
-            // 1. Turns out, I still need to get Contract from Contract service API, as the message doesn't contain the assetId as we assumed
-            var contract = await _contractApiGateway.GetContractByIdAsync(message.EntityId, message.CorrelationId)
-                                                .ConfigureAwait(false);
-            if (contract is null) throw new EntityNotFoundException<Contract>(message.EntityId);
-
-            // 2. Determine the Contract is for an Asset.
-            if (!contract.TargetType.ToLower().Equals("asset"))
-                throw new ArgumentException($"No charges of Types asset found for contract id: {contract.Id}");
-            _logger.LogInformation($"Contract with id {contract.Id} found. Now fetching Asset {contract.TargetId}");
-
-
-            //New process to handle multiple contracts
-            //1. Get Asset data from contract
-            var assetId = Guid.Parse(contract.TargetId);
-
-            // 2. Get asset from Asset API
-            var asset = await _assetApiGateway.GetAssetByIdAsync(assetId, message.CorrelationId)
-                                                .ConfigureAwait(false) ?? throw new EntityNotFoundException<QueryableAsset>(assetId);
-
-            // 3. Get all contracts from Contract API
-            var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false) ?? throw new EntityNotFoundException<List<Hackney.Shared.HousingSearch.Domain.Contract.Contract>>(assetId);
-
-            var allFilteredContracts = allContracts.Results.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
-            _logger.LogInformation($"{allFilteredContracts.Count()} contracts found.");
-            
-            // 4. Cycle over them to retrieve data 
-            var assetContracts = new List<QueryableAssetContract>(); 
-            foreach (var assetContract in allFilteredContracts)
+            _logger.LogInformation($"Contract with id {assetContract.Id} being added to asset");
+            var queryableAssetContract = new QueryableAssetContract
             {
-                _logger.LogInformation($"Contract with id {assetContract.Id} being added to asset");
-                var queryableAssetContract = new QueryableAssetContract
-                {
-                    Id = assetContract.Id,
-                    TargetId = assetContract.TargetId,
-                    TargetType = assetContract.TargetType,
-                    EndDate = assetContract.EndDate,
-                    EndReason = assetContract.EndReason,
-                    ApprovalStatus = assetContract.ApprovalStatus,
-                    ApprovalStatusReason = assetContract.ApprovalStatusReason,
-                    IsActive = assetContract.IsActive,
-                    ApprovalDate = assetContract.ApprovalDate,
-                    StartDate = assetContract.StartDate
-                };
+                Id = assetContract.Id,
+                TargetId = assetContract.TargetId,
+                TargetType = assetContract.TargetType,
+                EndDate = assetContract.EndDate,
+                EndReason = assetContract.EndReason,
+                ApprovalStatus = assetContract.ApprovalStatus,
+                ApprovalStatusReason = assetContract.ApprovalStatusReason,
+                IsActive = assetContract.IsActive,
+                ApprovalDate = assetContract.ApprovalDate,
+                StartDate = assetContract.StartDate
+            };
 
-                if (assetContract.Charges.Any())
-                {
-                    _logger.LogInformation($"{assetContract.Charges.Count()} charges found.");
-                    var charges = new List<QueryableCharges>();
+            if (assetContract.Charges.Any())
+            {
+                _logger.LogInformation($"{assetContract.Charges.Count()} charges found.");
+                var charges = new List<QueryableCharges>();
 
-                    foreach (var charge in assetContract.Charges)
+                foreach (var charge in assetContract.Charges)
+                {
+                    _logger.LogInformation(
+                        $"Charge with id {charge.Id} being added to asset with frequency {charge.Frequency}");
+                    var queryableCharge = new QueryableCharges
                     {
-                        _logger.LogInformation($"Charge with id {charge.Id} being added to asset with frequency {charge.Frequency}");
-                        var queryableCharge = new QueryableCharges
-                        {
-                            Id = charge.Id,
-                            Type = charge.Type,
-                            SubType = charge.SubType,
-                            Frequency = charge.Frequency,
-                            Amount = charge.Amount
-                        };
-                        charges.Add(queryableCharge);
-                    }
-
-                    queryableAssetContract.Charges = charges;
+                        Id = charge.Id,
+                        Type = charge.Type,
+                        SubType = charge.SubType,
+                        Frequency = charge.Frequency,
+                        Amount = charge.Amount
+                    };
+                    charges.Add(queryableCharge);
                 }
 
-                if (assetContract.RelatedPeople.Any())
-                {
-                    _logger.LogInformation($"{assetContract.RelatedPeople.Count()} related people found.");
-                    var relatedPeople = new List<QueryableRelatedPeople>();
-
-                    foreach (var relatedPerson in assetContract.RelatedPeople)
-                    {
-                        _logger.LogInformation($"Related person with id {relatedPerson.Id} being added to asset");
-                        var queryableRelatedPeople = new QueryableRelatedPeople
-                        {
-                            Id = relatedPerson.Id,
-                            Type = relatedPerson.Type,
-                            SubType = relatedPerson.SubType,
-                            Name = relatedPerson.Name,
-                        };
-                        relatedPeople.Add(queryableRelatedPeople);
-                    }
-
-                    queryableAssetContract.RelatedPeople = relatedPeople;
-                }
-                assetContracts.Add(queryableAssetContract);
+                queryableAssetContract.Charges = charges;
             }
-            
-            asset.AssetContracts = assetContracts;
-            
-            // 5. Update the indexes
-            await UpdateAssetIndexAsync(asset);
+
+            if (assetContract.RelatedPeople.Any())
+            {
+                _logger.LogInformation($"{assetContract.RelatedPeople.Count()} related people found.");
+                var relatedPeople = new List<QueryableRelatedPeople>();
+
+                foreach (var relatedPerson in assetContract.RelatedPeople)
+                {
+                    _logger.LogInformation($"Related person with id {relatedPerson.Id} being added to asset");
+                    var queryableRelatedPeople = new QueryableRelatedPeople
+                    {
+                        Id = relatedPerson.Id,
+                        Type = relatedPerson.Type,
+                        SubType = relatedPerson.SubType,
+                        Name = relatedPerson.Name
+                    };
+                    relatedPeople.Add(queryableRelatedPeople);
+                }
+
+                queryableAssetContract.RelatedPeople = relatedPeople;
+            }
+
+            assetContracts.Add(queryableAssetContract);
         }
-        private async Task UpdateAssetIndexAsync(QueryableAsset asset)
-        {
-            var esAsset = await _esGateway.GetAssetById(asset.Id.ToString()).ConfigureAwait(false);
-            if (esAsset is null)
-                throw new ArgumentException($"No asset found in index with id: {asset.Id}");
-            esAsset = _esEntityFactory.CreateAsset(asset);
-            await _esGateway.IndexAsset(esAsset);
-        }
+
+        asset.AssetContracts = assetContracts;
+
+        // 5. Update the indexes
+        await UpdateAssetIndexAsync(asset);
+    }
+
+    private async Task UpdateAssetIndexAsync(QueryableAsset asset)
+    {
+        var esAsset = await _esGateway.GetAssetById(asset.Id).ConfigureAwait(false);
+        if (esAsset is null)
+            throw new ArgumentException($"No asset found in index with id: {asset.Id}");
+        esAsset = _esEntityFactory.CreateAsset(asset);
+        await _esGateway.IndexAsset(esAsset);
     }
 }


### PR DESCRIPTION
**Apologies for the super noisy PR - I ran code cleanup to fix some circle-ci formatting issues, with predictable results.**

Fix for a bug where `QueryableAssets` were not updated in the index if they did not have any no-approved contracts.

The actual changes were in `AddOrUpdateContractInAssetUseCase`, and involved removing the `if (allFilteredContracts.Any())` statement and moving the ` await UpdateAssetIndexAsync(asset);` call outside the contract processing loop. 

Not the asset is updated in all cases, regardless of the contracts it has.




