### PR TITLE
TS-1923: Always update the asset in the index regardless of contract status

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -37,14 +37,14 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
                                      .CreateMany(1).ToList();
             return new PagedResult<Contract> { Results = ResponseObject };
         }
-        
+
         public PagedResult<Contract> GivenApprovedContractsAreReturned(Guid contractId, Guid targetId)
         {
             var ResponseObject = _fixture.Build<Contract>()
                 .With(x => x.Id, contractId.ToString())
                 .With(x => x.TargetId, targetId.ToString())
                 .With(x => x.TargetType, "asset")
-                .With(x => x.ApprovalStatus, "Approve")
+                .With(x => x.ApprovalStatus, "Approved")
                 .CreateMany(2).ToList();
             return new PagedResult<Contract> { Results = ResponseObject };
         }

--- a/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Fixtures/MultipleContractApiFixture.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-
 namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
 {
     public class MultipleContractApiFixture : BaseApiFixture<IEnumerable<Contract>>
@@ -36,6 +35,17 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Fixtures
                                      .With(x => x.TargetId, targetId.ToString())
                                      .With(x => x.TargetType, "asset")
                                      .CreateMany(1).ToList();
+            return new PagedResult<Contract> { Results = ResponseObject };
+        }
+        
+        public PagedResult<Contract> GivenApprovedContractsAreReturned(Guid contractId, Guid targetId)
+        {
+            var ResponseObject = _fixture.Build<Contract>()
+                .With(x => x.Id, contractId.ToString())
+                .With(x => x.TargetId, targetId.ToString())
+                .With(x => x.TargetType, "asset")
+                .With(x => x.ApprovalStatus, "Approve")
+                .CreateMany(2).ToList();
             return new PagedResult<Contract> { Results = ResponseObject };
         }
     }

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -63,5 +63,14 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
             var assetInIndex = result.Source;
             assetInIndex.AssetContracts.Should().BeEquivalentTo(contracts);
         }
+        
+        public async Task ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(QueryableAsset asset, IElasticClient esClient)
+        {
+            var result = await esClient.GetAsync<QueryableAsset>(asset.Id, g => g.Index("assets"))
+                                       .ConfigureAwait(false);
+
+            var assetInIndex = result.Source;
+            assetInIndex.AssetContracts.Should().BeEquivalentTo(new List<Contract>());
+        }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -63,14 +63,14 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
             var assetInIndex = result.Source;
             assetInIndex.AssetContracts.Should().BeEquivalentTo(contracts);
         }
-        
+
         public async Task ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(QueryableAsset asset, IElasticClient esClient)
         {
             var result = await esClient.GetAsync<QueryableAsset>(asset.Id, g => g.Index("assets"))
                                        .ConfigureAwait(false);
 
             var assetInIndex = result.Source;
-            assetInIndex.AssetContracts.Should().BeEquivalentTo(new List<Contract>());
+            assetInIndex.AssetContracts.Should().BeNull();
         }
     }
 }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -50,7 +50,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         }
 
         [Theory]
-        // [InlineData(EventTypes.ContractCreatedEvent)]
+        [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]
         public void AssetNotFound(string eventType)
         {

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -48,7 +48,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                 _disposed = true;
             }
         }
-        
+
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -48,8 +48,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                 _disposed = true;
             }
         }
-
-
+        
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -79,7 +79,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                     _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();
         }
-        
+
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]
@@ -91,7 +91,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
                 .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
-                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(_AssetApiFixture.ResponseObject, 
+                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(_AssetApiFixture.ResponseObject,
                     _esFixture.ElasticSearchClient))
                 .BDDfy();
         }

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -50,7 +50,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         }
 
         [Theory]
-        [InlineData(EventTypes.ContractCreatedEvent)]
+        // [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]
         public void AssetNotFound(string eventType)
         {

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -82,7 +82,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]
         [InlineData(EventTypes.ContractUpdatedEvent)]
-        public void ContractNotAddedToAssetWhenNoUnapprovedContractsAreAvailable(string eventType)
+        public void ContractNotAddedToAssetWhenNoUnapprovedContractsArePresent(string eventType)
         {
             var contractId = Guid.NewGuid();
             var assetId = Guid.NewGuid();

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -79,5 +79,21 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
                     _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();
         }
+        
+        [Theory]
+        [InlineData(EventTypes.ContractCreatedEvent)]
+        [InlineData(EventTypes.ContractUpdatedEvent)]
+        public void ContractNotAddedToAssetWhenNoUnapprovedContractsAreAvailable(string eventType)
+        {
+            var contractId = Guid.NewGuid();
+            var assetId = Guid.NewGuid();
+            this.Given(g => _ContractsApiFixture.GivenApprovedContractsAreReturned(contractId, assetId))
+                .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
+                .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+                .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(_AssetApiFixture.ResponseObject, 
+                    _esFixture.ElasticSearchClient))
+                .BDDfy();
+        }
     }
 }

--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -65,7 +65,7 @@ namespace HousingSearchListener.V1.UseCase
             var allFilteredContracts = allContracts.Results.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
 
             // 4. Cycle over them to retrieve data 
-            var assetContracts = new List<QueryableAssetContract>(); 
+            var assetContracts = new List<QueryableAssetContract>();
             foreach (var assetContract in allFilteredContracts)
             {
                 _logger.LogInformation($"Contract with id {assetContract.Id} being added to asset");
@@ -127,13 +127,13 @@ namespace HousingSearchListener.V1.UseCase
                 }
                 assetContracts.Add(queryableAssetContract);
             }
-            
+
             asset.AssetContracts = assetContracts;
-            
+
             // 5. Update the indexes
             await UpdateAssetIndexAsync(asset);
         }
-        
+
         private async Task UpdateAssetIndexAsync(QueryableAsset asset)
         {
             var esAsset = await _esGateway.GetAssetById(asset.Id.ToString()).ConfigureAwait(false);


### PR DESCRIPTION
Fix for a bug where `QueryableAssets` were not updated in the index if they did not have any no-approved contracts.

The PR looks worse than the change is due to the removal of a layer of indentation changes the formatting. The actual changes are in `AddOrUpdateContractInAssetUseCase`, and involved removing the `if (allFilteredContracts.Any())` statement and moving the  `await UpdateAssetIndexAsync(asset);` call outside the contract processing loop.

Now the asset is updated in all cases, regardless of the contracts it has.