### PR TITLE
Fix/ts-1940 map contract charges correctly

### DIFF
--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -201,6 +201,40 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.ParentAssetIds.Should().Be(domainAsset.ParentAssetIds);
             result.RootAsset.Should().Be(domainAsset.RootAsset);
         }
+        
+        [Fact]
+        public void CreateAssetContractChargesAreMappedCorrectly()
+        {
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                .With(c => c.TargetType, "asset")
+                .CreateMany(2)
+                .ToList();
+
+            var domainAsset = _fixture.Build<QueryableAsset>()
+                .With(a => a.AssetContracts, contracts).Create();
+
+            var result = _sut.CreateAsset(domainAsset);
+
+            result.AssetContracts[0].Charges.Should().BeEquivalentTo(domainAsset.AssetContracts[0].Charges);
+            result.AssetContracts[1].Charges.Should().BeEquivalentTo(domainAsset.AssetContracts[1].Charges);
+        }
+        
+        [Fact]
+        public void CreateAssetContractRelatedPeopleAreMappedCorrectly()
+        {
+            var contracts = _fixture.Build<QueryableAssetContract>()
+                .With(c => c.TargetType, "asset")
+                .CreateMany(2)
+                .ToList();
+
+            var domainAsset = _fixture.Build<QueryableAsset>()
+                .With(a => a.AssetContracts, contracts).Create();
+
+            var result = _sut.CreateAsset(domainAsset);
+
+            result.AssetContracts[0].RelatedPeople.Should().BeEquivalentTo(domainAsset.AssetContracts[0].RelatedPeople);
+            result.AssetContracts[1].RelatedPeople.Should().BeEquivalentTo(domainAsset.AssetContracts[1].RelatedPeople);
+        }
 
         [Fact]
         public void CreateAssetCanHandleNullAssetContractCharges()

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -201,40 +201,6 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.ParentAssetIds.Should().Be(domainAsset.ParentAssetIds);
             result.RootAsset.Should().Be(domainAsset.RootAsset);
         }
-        
-        [Fact]
-        public void CreateAssetContractChargesAreMappedCorrectly()
-        {
-            var contracts = _fixture.Build<QueryableAssetContract>()
-                .With(c => c.TargetType, "asset")
-                .CreateMany(2)
-                .ToList();
-
-            var domainAsset = _fixture.Build<QueryableAsset>()
-                .With(a => a.AssetContracts, contracts).Create();
-
-            var result = _sut.CreateAsset(domainAsset);
-
-            result.AssetContracts[0].Charges.Should().BeEquivalentTo(domainAsset.AssetContracts[0].Charges);
-            result.AssetContracts[1].Charges.Should().BeEquivalentTo(domainAsset.AssetContracts[1].Charges);
-        }
-        
-        [Fact]
-        public void CreateAssetContractRelatedPeopleAreMappedCorrectly()
-        {
-            var contracts = _fixture.Build<QueryableAssetContract>()
-                .With(c => c.TargetType, "asset")
-                .CreateMany(2)
-                .ToList();
-
-            var domainAsset = _fixture.Build<QueryableAsset>()
-                .With(a => a.AssetContracts, contracts).Create();
-
-            var result = _sut.CreateAsset(domainAsset);
-
-            result.AssetContracts[0].RelatedPeople.Should().BeEquivalentTo(domainAsset.AssetContracts[0].RelatedPeople);
-            result.AssetContracts[1].RelatedPeople.Should().BeEquivalentTo(domainAsset.AssetContracts[1].RelatedPeople);
-        }
 
         [Fact]
         public void CreateAssetCanHandleNullAssetContractCharges()

--- a/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
+++ b/HousingSearchListener.Tests/V1/Factories/ESEntityFactoryTests.cs
@@ -201,7 +201,7 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.ParentAssetIds.Should().Be(domainAsset.ParentAssetIds);
             result.RootAsset.Should().Be(domainAsset.RootAsset);
         }
-        
+
         [Fact]
         public void CreateAssetContractChargesAreMappedCorrectly()
         {
@@ -218,7 +218,7 @@ namespace HousingSearchListener.Tests.V1.Factories
             result.AssetContracts[0].Charges.Should().BeEquivalentTo(domainAsset.AssetContracts[0].Charges);
             result.AssetContracts[1].Charges.Should().BeEquivalentTo(domainAsset.AssetContracts[1].Charges);
         }
-        
+
         [Fact]
         public void CreateAssetContractRelatedPeopleAreMappedCorrectly()
         {

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -164,6 +164,8 @@ namespace HousingSearchListener.V1.Factories
             QueryableAssetManagement assetManagement = new QueryableAssetManagement();
             QueryableAssetLocation assetLocation = new QueryableAssetLocation();
             List<QueryableAssetContract> queryableAssetContracts = new List<QueryableAssetContract>();
+            List<QueryableCharges> queryableCharges = new List<QueryableCharges>();
+            List<QueryableRelatedPeople> queryableRelatedPeople = new List<QueryableRelatedPeople>();
 
             queryableAsset.Id = asset.Id.ToString();
             queryableAsset.AssetId = asset.AssetId;
@@ -252,7 +254,6 @@ namespace HousingSearchListener.V1.Factories
 
                     if (contract.Charges != null)
                     {
-                        var queryableCharges = new List<QueryableCharges>();
                         foreach (var charge in contract.Charges)
                         {
                             var queryableCharge = new QueryableCharges
@@ -270,7 +271,6 @@ namespace HousingSearchListener.V1.Factories
 
                     if (contract.RelatedPeople != null)
                     {
-                        var queryableRelatedPeople = new List<QueryableRelatedPeople>();
                         foreach (var relatedPerson in contract.RelatedPeople)
                         {
                             var queryableRelatedPerson = new QueryableRelatedPeople

--- a/HousingSearchListener/V1/Factories/ESEntityFactory.cs
+++ b/HousingSearchListener/V1/Factories/ESEntityFactory.cs
@@ -164,8 +164,6 @@ namespace HousingSearchListener.V1.Factories
             QueryableAssetManagement assetManagement = new QueryableAssetManagement();
             QueryableAssetLocation assetLocation = new QueryableAssetLocation();
             List<QueryableAssetContract> queryableAssetContracts = new List<QueryableAssetContract>();
-            List<QueryableCharges> queryableCharges = new List<QueryableCharges>();
-            List<QueryableRelatedPeople> queryableRelatedPeople = new List<QueryableRelatedPeople>();
 
             queryableAsset.Id = asset.Id.ToString();
             queryableAsset.AssetId = asset.AssetId;
@@ -254,6 +252,7 @@ namespace HousingSearchListener.V1.Factories
 
                     if (contract.Charges != null)
                     {
+                        var queryableCharges = new List<QueryableCharges>();
                         foreach (var charge in contract.Charges)
                         {
                             var queryableCharge = new QueryableCharges
@@ -271,6 +270,7 @@ namespace HousingSearchListener.V1.Factories
 
                     if (contract.RelatedPeople != null)
                     {
+                        var queryableRelatedPeople = new List<QueryableRelatedPeople>();
                         foreach (var relatedPerson in contract.RelatedPeople)
                         {
                             var queryableRelatedPerson = new QueryableRelatedPeople


### PR DESCRIPTION
The `Charges` and `RelatedPeople` collections of each `AssetContract` were duplicated across all `AssetContracts` due to the collections used to hold them being initialised outside of the processing loop, meaning the collection was not empty with each iteration.