### PR TITLE
TS-1937: Intermittently failing test

### DIFF
--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/AddOrUpdateContractOnAssetTestsSteps.cs
@@ -18,9 +18,9 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
             _eventType = EventTypes.ContractCreatedEvent;
         }
 
-        public async Task WhenTheFunctionIsTriggered(Guid contractId, string eventType, string targetType)
+        public async Task WhenTheFunctionIsTriggered(Guid contractId, string eventType)
         {
-            var eventMsg = CreateEvent(contractId, eventType, targetType);
+            var eventMsg = CreateEvent(contractId, eventType);
             await TriggerFunction(CreateMessage(eventMsg));
         }
 

--- a/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Steps/BaseSteps.cs
@@ -45,22 +45,12 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Steps
         }
 
 
-        protected EntityEventSns CreateEvent(Guid entityId, string eventType, string targetId = null)
+        protected EntityEventSns CreateEvent(Guid entityId, string eventType)
         {
             var EntityEventBuilder = _fixture.Build<EntityEventSns>()
                                 .With(x => x.EntityId, entityId)
                                 .With(x => x.EventType, eventType)
                                 .With(x => x.CorrelationId, _correlationId);
-
-            //had to make this conditional as it was messing with preexisting tests
-            if (targetId != null)
-            {
-                EntityEventBuilder = EntityEventBuilder.With(x => x.EventData, new EventData
-                {
-                    NewData = new { Id = targetId }
-                });
-            }
-
             return EntityEventBuilder.Create();
         }
 

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -51,7 +51,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
 
         [Theory]
         [InlineData(EventTypes.ContractCreatedEvent)]
-        [InlineData(EventTypes.ContractUpdatedEvent, Skip = "test fails intermittently, further investigation required")]
+        [InlineData(EventTypes.ContractUpdatedEvent)]
         public void AssetNotFound(string eventType)
         {
             var contractId = Guid.NewGuid();

--- a/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
+++ b/HousingSearchListener.Tests/V1/E2ETests/Stories/AddOrUpdateContractOnAssetTests.cs
@@ -58,7 +58,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             var assetId = Guid.NewGuid();
             this.Given(g => _ContractApiFixture.GivenTheContractExists(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetDoesNotExist(assetId))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
                 .Then(t => _steps.ThenAnAssetNotFoundExceptionIsThrown(assetId))
                 .BDDfy();
         }
@@ -73,7 +73,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             this.Given(g => _ContractsApiFixture.GivenMultipleContractsAreReturned(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
                 .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedWithTheContracts(_AssetApiFixture.ResponseObject,
                     _ContractsApiFixture.ResponseObject, _esFixture.ElasticSearchClient))
                 .BDDfy();
@@ -89,7 +89,7 @@ namespace HousingSearchListener.Tests.V1.E2ETests.Stories
             this.Given(g => _ContractsApiFixture.GivenApprovedContractsAreReturned(contractId, assetId))
                 .And(g => _AssetApiFixture.GivenTheAssetExists(assetId))
                 .And(g => _esFixture.GivenAnAssetIsIndexed(assetId.ToString()))
-                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType, assetId.ToString()))
+                .When(w => _steps.WhenTheFunctionIsTriggered(contractId, eventType))
                 .Then(t => _steps.ThenTheAssetInTheIndexIsUpdatedAndHasNoContracts(_AssetApiFixture.ResponseObject,
                     _esFixture.ElasticSearchClient))
                 .BDDfy();


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-1937 

## Describe this PR

We had a test that failed intermittently on the pipeline, because it was still operating on wrong assumptions (see this [PR](https://github.com/LBHackney-IT/housing-search-listener/pull/140))
Now it's aligned with how the message looks like and it's not ❄️ anymore, yay!
