### PR TITLE
BTA - Carry over approved contracts too

### DIFF
--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -62,7 +62,7 @@ namespace HousingSearchListener.V1.UseCase
             // 3. Get all contracts from Contract API
             var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false) ?? throw new EntityNotFoundException<List<Hackney.Shared.HousingSearch.Domain.Contract.Contract>>(assetId);
 
-            var allFilteredContracts = allContracts.Results.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
+            var allFilteredContracts = allContracts.Results.Where(x => x?.EndReason != "ContractNoLongerNeeded");
 
             // 4. Cycle over them to retrieve data 
             var assetContracts = new List<QueryableAssetContract>();


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/TS-2027

## Describe this PR

### *What is the problem we're trying to solve*

When we adapted the Assets to include multiple contracts (see [here](https://github.com/LBHackney-IT/housing-search-listener/pull/137/) for the main PR) we needed to ignore Approved contract.
This has now changed, as we need to carry over Approved contracts to ES too. Filtering on status is already present on the FE where needed.

### *What changes have we introduced*

Deleted unneeded Where condition in filter

### *Follow up actions after merging PR*

None