### PR TITLE
BTA - Rollback to not carrying over approved contracts for now

### DIFF
--- a/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
+++ b/HousingSearchListener/V1/UseCase/AddOrUpdateContractInAssetUseCase.cs
@@ -62,7 +62,7 @@ namespace HousingSearchListener.V1.UseCase
             // 3. Get all contracts from Contract API
             var allContracts = await _contractApiGateway.GetContractsByAssetIdAsync(assetId, message.CorrelationId).ConfigureAwait(false) ?? throw new EntityNotFoundException<List<Hackney.Shared.HousingSearch.Domain.Contract.Contract>>(assetId);
 
-            var allFilteredContracts = allContracts.Results.Where(x => x?.EndReason != "ContractNoLongerNeeded");
+            var allFilteredContracts = allContracts.Results.Where(x => x?.ApprovalStatus != "Approved").Where(x => x?.EndReason != "ContractNoLongerNeeded");
 
             // 4. Cycle over them to retrieve data 
             var assetContracts = new List<QueryableAssetContract>();


### PR DESCRIPTION
This is a rollback of this [PR](https://github.com/LBHackney-IT/housing-search-listener/pull/160).
Having Approved contracts in the index means more work will be needed get better filtering on the API. As there are multiple contracts for an asset, we will need to figure out how to properly filter those.
We have therefore decided to temporarily roll this back in view of upcoming test work (it's best to have a streamlined Dev/Staging situation) and address the changes that are needed in a future piece of work.
Apologies!