### PR TITLE
Skip unsupported event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,9 @@ jobs:
     executor: docker-python
     steps:
       - checkout
+      - run:
+          name: Fetch full git history for SonarCloud
+          command: git fetch --unshallow
       - setup_remote_docker
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,9 +143,6 @@ jobs:
     executor: docker-python
     steps:
       - checkout
-      - run:
-          name: Fetch full git history for SonarCloud
-          command: git fetch --unshallow
       - setup_remote_docker
       - run:
           name: build

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -11,14 +11,22 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-RUN apk update && apk add --no-cache nodejs
-
 RUN dotnet tool install --global dotnet-sonarscanner
 RUN dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.2.0
 
 ENV PATH="$PATH:/root/.dotnet/tools"
 
+# Copy csproj and nuget config and restore as distinct layers
+COPY HousingSearchListener/HousingSearchListener.csproj ./HousingSearchListener/
+COPY HousingSearchListener.Tests/HousingSearchListener.Tests.csproj ./HousingSearchListener.Tests/
+COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
+RUN dotnet restore ./HousingSearchListener/HousingSearchListener.csproj
+RUN dotnet restore ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
+
+# Copy everything else and build
 COPY . .
+RUN dotnet build ./HousingSearchListener/HousingSearchListener.csproj
+RUN dotnet build ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
 
 CMD if [ -n "$SONAR_TOKEN" ]; then \
       dotnet sonarscanner begin \

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'
@@ -11,27 +11,33 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openjdk21
+RUN apk update && apk add --no-cache nodejs
+
+RUN apk update \
+ && apk upgrade --no-cache \
+ && apk add --no-cache openjdk21
+
 RUN dotnet tool install --global dotnet-sonarscanner
+RUN dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.2.0
+
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_housing-search-listener" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner begin \
+    /k:"LBHackney-IT_housing-search-listener" \
+    /o:"lbhackney-it" \
+    /d:sonar.host.url=https://sonarcloud.io \
+    /d:sonar.login="${SONAR_TOKEN}" \
+    /d:sonar.coverageReportPaths="coverage/SonarQube.xml" \
+    /d:sonar.dotnet.excludeTestProjects=true \
+    /d:sonar.exclusions="**/*.js, **/*.ts, **/*.css"
 
-
-# Copy csproj and nuget config and restore as distinct layers
-COPY ./HousingSearchListener.sln ./
-COPY ./HousingSearchListener/HousingSearchListener.csproj ./HousingSearchListener/
-COPY ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj ./HousingSearchListener.Tests/
-COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
-
-RUN dotnet restore ./HousingSearchListener/HousingSearchListener.csproj
-RUN dotnet restore ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
-
-# Copy everything else and build
 COPY . .
 
-RUN dotnet build -c Release -o out HousingSearchListener/HousingSearchListener.csproj
-RUN dotnet build -c debug -o out HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
+RUN dotnet restore
 
-CMD dotnet test
-RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet build ./HousingSearchListener/HousingSearchListener.csproj --no-restore --no-dependencies
+RUN dotnet build ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj --no-restore
+
+CMD dotnet test ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage \
+    && reportgenerator "-reports:./coverage/*/coverage.cobertura.xml" "-targetdir:coverage" "-reporttypes:SonarQube" "-verbosity:Off" \
+    && (dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}" > /dev/null)

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -11,7 +11,7 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openjdk-17-jdk
+RUN apt-get update && apt-get install -y openjdk-21-jdk
 RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -25,8 +25,9 @@ RUN dotnet restore ./HousingSearchListener.Tests/HousingSearchListener.Tests.csp
 
 # Copy everything else and build
 COPY . .
-RUN dotnet build ./HousingSearchListener/HousingSearchListener.csproj
-RUN dotnet build ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
+
+RUN dotnet build -c Release -o out HousingSearchListener/HousingSearchListener.csproj
+RUN dotnet build -c debug -o out HousingSearchListener.Tests/HousingSearchListener.Tests.csproj
 
 CMD if [ -n "$SONAR_TOKEN" ]; then \
       dotnet sonarscanner begin \

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -25,6 +25,7 @@ CMD if [ -n "$SONAR_TOKEN" ]; then \
         /k:"LBHackney-IT_housing-search-listener" \
         /o:"lbhackney-it" \
         /d:sonar.host.url=https://sonarcloud.io \
+        /d:sonar.scm.disabled=true \
         /d:sonar.login="${SONAR_TOKEN}" && \
       dotnet test && \
       dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"; \

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -13,10 +13,6 @@ WORKDIR /app
 
 RUN apk update && apk add --no-cache nodejs
 
-RUN apk update \
-    && apk upgrade --no-cache \
-    && apk add --no-cache openjdk21-jre
-
 RUN dotnet tool install --global dotnet-sonarscanner
 RUN dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.2.0
 

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -14,30 +14,24 @@ WORKDIR /app
 RUN apk update && apk add --no-cache nodejs
 
 RUN apk update \
- && apk upgrade --no-cache \
- && apk add --no-cache openjdk21
+    && apk upgrade --no-cache \
+    && apk add --no-cache openjdk21-jre
 
 RUN dotnet tool install --global dotnet-sonarscanner
 RUN dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.2.0
 
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet sonarscanner begin \
-    /k:"LBHackney-IT_housing-search-listener" \
-    /o:"lbhackney-it" \
-    /d:sonar.host.url=https://sonarcloud.io \
-    /d:sonar.login="${SONAR_TOKEN}" \
-    /d:sonar.coverageReportPaths="coverage/SonarQube.xml" \
-    /d:sonar.dotnet.excludeTestProjects=true \
-    /d:sonar.exclusions="**/*.js, **/*.ts, **/*.css"
-
 COPY . .
 
-RUN dotnet restore
-
-RUN dotnet build ./HousingSearchListener/HousingSearchListener.csproj --no-restore --no-dependencies
-RUN dotnet build ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj --no-restore
-
-CMD dotnet test ./HousingSearchListener.Tests/HousingSearchListener.Tests.csproj --no-build --collect:"XPlat Code Coverage" --results-directory ./coverage \
-    && reportgenerator "-reports:./coverage/*/coverage.cobertura.xml" "-targetdir:coverage" "-reporttypes:SonarQube" "-verbosity:Off" \
-    && (dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}" > /dev/null)
+CMD if [ -n "$SONAR_TOKEN" ]; then \
+      dotnet sonarscanner begin \
+        /k:"LBHackney-IT_housing-search-listener" \
+        /o:"lbhackney-it" \
+        /d:sonar.host.url=https://sonarcloud.io \
+        /d:sonar.login="${SONAR_TOKEN}" && \
+      dotnet test && \
+      dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"; \
+    else \
+      dotnet test; \
+    fi

--- a/HousingSearchListener.Tests/Dockerfile
+++ b/HousingSearchListener.Tests/Dockerfile
@@ -11,7 +11,7 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y openjdk-21-jdk
+RUN apt-get update && apt-get install -y openjdk21
 RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 

--- a/HousingSearchListener/V1/Boundary/EventTypes.cs
+++ b/HousingSearchListener/V1/Boundary/EventTypes.cs
@@ -24,5 +24,7 @@ namespace HousingSearchListener.V1.Boundary
 
         public const string ContractCreatedEvent = "ContractCreatedEvent";
         public const string ContractUpdatedEvent = "ContractUpdatedEvent";
+        
+        public const string AddRepairsContractsToAssetEvent = "AddRepairsContractsToAssetEvent";
     }
 }

--- a/HousingSearchListener/V1/Boundary/EventTypes.cs
+++ b/HousingSearchListener/V1/Boundary/EventTypes.cs
@@ -24,7 +24,7 @@ namespace HousingSearchListener.V1.Boundary
 
         public const string ContractCreatedEvent = "ContractCreatedEvent";
         public const string ContractUpdatedEvent = "ContractUpdatedEvent";
-        
+
         public const string AddRepairsContractsToAssetEvent = "AddRepairsContractsToAssetEvent";
     }
 }

--- a/HousingSearchListener/V1/Factories/UseCaseFactory.cs
+++ b/HousingSearchListener/V1/Factories/UseCaseFactory.cs
@@ -81,6 +81,12 @@ namespace HousingSearchListener.V1.Factories
                         processor = serviceProvider.GetService<IAddOrUpdateContractInAssetUseCase>();
                         break;
                     }
+                // Unsupported event types
+                case EventTypes.AddRepairsContractsToAssetEvent:
+                    {
+                        Console.WriteLine($"Skipping unsupported event type: {entityEvent.EventType}");
+                        break;
+                    }
                 default:
                     throw new ArgumentException($"Unknown event type: {entityEvent.EventType}");
             }

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
-	docker compose build housing-search-listener-tests && \ 
+	docker compose build housing-search-listener-tests && \
 	docker compose run housing-search-listener-tests


### PR DESCRIPTION
We have a bug where the asset listener receives the "AddRepairsContractsToAssetEvent" on asset creation, which creates a loop of try-retry on those events causing significant delays to asset creation via API.

This adds a skip for this event type to streamline asset creation via API - since we've had several requests to create new assets recently.